### PR TITLE
refactor: remove legacy code, add boot_tests feature, fix smoke tests

### DIFF
--- a/book/src/architecture/overview.md
+++ b/book/src/architecture/overview.md
@@ -16,7 +16,7 @@ Transitions between worlds are controlled by hardware:
 Umbra provides the Secure World runtime. It:
 
 1. **Boots first** — the vector table is in Secure flash; Umbra initializes SAU, GTZC, MPU, and peripherals before handing control to the Non-Secure host
-2. **Provides APIs** — 6 NSC veneers allow the host to create, enter, exit, and query enclaves
+2. **Provides APIs** — 5 NSC veneers allow the host to create, enter, exit, and query enclaves
 3. **Manages enclaves** — loads encrypted code from flash, validates integrity (HMAC), decrypts (AES), and installs into Secure SRAM
 4. **Enforces isolation** — MPU regions protect kernel memory from enclave code; MPCBB controls 256-byte block-level SRAM security
 

--- a/book/src/getting-started/build-and-run.md
+++ b/book/src/getting-started/build-and-run.md
@@ -38,17 +38,15 @@ Connect to the ST-Link UART at **9600 baud**:
 
 ```
 [UMBRASecureBoot] Secure Boot started
-[UMBRASecureBoot] SAU started
-[UMBRASecureBoot] GTZC started
 [UMBRASecureBoot] Kernel Initialized
-[UMBRASecureBoot] SysTick configured (disabled)
 [UMBRASecureBoot] Jumping to Non-Secure World
 [USER] Hello Non-Secure World!
-[UMBRASecureBoot] chained-measurement OK
 [USER] Enclave created
 [USER] Enclave terminated! R0=0x72CA33A8
 [USER] All enclaves done
 ```
+
+Note: additional diagnostic output (stack info, SAU/GTZC/MPU status, HASH/AES tests) is available by building with the `boot_tests` feature enabled.
 
 ## Smoke Tests
 

--- a/host/bare_metal_arm/linker/host.ld
+++ b/host/bare_metal_arm/linker/host.ld
@@ -88,9 +88,8 @@ SECTIONS
 /* These are the SG entry points in _NSC_TEXT_MEMORY_, not the _imp implementations */
 /* Addresses from 'nm boot | grep umbra_' after building secureboot */
 /* TODO: Update these addresses after each secure rebuild, or use import lib mechanism */
-PROVIDE(umbra_tee_create = 0x0803c001);   /* Thumb mode address of umbra_tee_create veneer */
-PROVIDE(umbra_enclave_run = 0x0803c011);  /* Thumb mode address of umbra_enclave_run veneer */
-PROVIDE(umbra_debug_print = 0x0803c021);  /* Thumb mode address of umbra_debug_print veneer */
-PROVIDE(umbra_enclave_enter = 0x0803c031);  /* Thumb mode address of umbra_enclave_enter veneer */
-PROVIDE(umbra_enclave_exit = 0x0803c041);   /* Thumb mode address of umbra_enclave_exit veneer */
-PROVIDE(umbra_enclave_status = 0x0803c051); /* Thumb mode address of umbra_enclave_status veneer */
+PROVIDE(umbra_tee_create = 0x0803c001);     /* Thumb mode address of umbra_tee_create veneer */
+PROVIDE(umbra_debug_print = 0x0803c011);    /* Thumb mode address of umbra_debug_print veneer */
+PROVIDE(umbra_enclave_enter = 0x0803c021);  /* Thumb mode address of umbra_enclave_enter veneer */
+PROVIDE(umbra_enclave_exit = 0x0803c031);   /* Thumb mode address of umbra_enclave_exit veneer */
+PROVIDE(umbra_enclave_status = 0x0803c041); /* Thumb mode address of umbra_enclave_status veneer */

--- a/host/bare_metal_arm/src/main.c
+++ b/host/bare_metal_arm/src/main.c
@@ -29,7 +29,6 @@ const uint8_t enclave_header[48] = {
     0xCC, 0xC8, 0x30, 0x59, 0x03, 0xCC, 0xD9, 0x36};
 
 extern unsigned int umbra_tee_create(unsigned int base_addr);
-extern unsigned int umbra_enclave_run(void);
 extern void umbra_debug_print(const char *s);
 extern unsigned int umbra_enclave_enter(unsigned int enclave_id);
 extern unsigned int umbra_enclave_status(unsigned int enclave_id);

--- a/linker/umbra.ld
+++ b/linker/umbra.ld
@@ -23,7 +23,6 @@ SECTIONS
     .umbra_api_implementation :
     {
         KEEP(*(.text.umbra_tee_create_imp))
-        KEEP(*(.text.umbra_enclave_run_imp))
         KEEP(*(.text.umbra_debug_print_imp))
         KEEP(*(.text.umbra_enclave_enter_imp))
         KEEP(*(.text.umbra_enclave_exit_imp))

--- a/src/hardware/platform/stm32l552/boot/Cargo.toml
+++ b/src/hardware/platform/stm32l552/boot/Cargo.toml
@@ -12,6 +12,7 @@ peripheral_regs = { path = "../../../common/peripheral_regs" }
 
 [features]
 default = ["chained_measurement", "ess_miss_recovery"]
+boot_tests = []
 stm32l562 = ["drivers/stm32l562"]
 chained_measurement = []
 ess_miss_recovery = []

--- a/src/hardware/platform/stm32l552/boot/src/api_impl.rs
+++ b/src/hardware/platform/stm32l552/boot/src/api_impl.rs
@@ -172,6 +172,7 @@ pub extern "C" fn umbra_tee_create_imp(base_addr: u32) -> u32{
             umbra_debug_print_imp(b"[UMBRASecureBoot] chained-measurement FAIL\n\0".as_ptr());
             return 0xFFFFFFF6;
         }
+        #[cfg(feature = "boot_tests")]
         umbra_debug_print_imp(b"[UMBRASecureBoot] chained-measurement OK\n\0".as_ptr());
     }
 
@@ -465,48 +466,6 @@ pub extern "C" fn umbra_enclave_status_imp(enclave_id: u32) -> u32 {
     0xFF
 }
 
-
-#[no_mangle]
-#[link_section = ".umbra_api_implementation"]
-pub extern "C" fn umbra_enclave_run_imp() -> u32 {
-    
-    let kernel = unsafe {
-        match Kernel::get() {
-            Some(k) => k,
-            None => return 0xFFFFFFFE,
-        }
-    };
-    
-    let mut entry_point: u32 = 0;
-    let mut found = false;
-    
-    for slot in kernel.ess.loaded_enclaves.iter() {
-        if let Some(loaded) = slot {
-             entry_point = loaded.descriptor.entry_point; // Use entry_point from descriptor
-             found = true;
-             break;
-        }
-    }
-    
-    if !found {
-        return 0xFFFFFFF0; 
-    }
-
-    let result: u32;
-    unsafe {
-        // Ensure Thumb state
-        let entry_point_thumb: u32 = entry_point | 1;
-        core::arch::asm!(
-            "dsb",
-            "isb",
-            "blx {0}",
-            in(reg) entry_point_thumb,
-            lateout("r0") result,
-            clobber_abi("C")
-        );
-    }
-    return result;
-}
 
 #[no_mangle]
 #[link_section = ".umbra_api_implementation"]

--- a/src/hardware/platform/stm32l552/boot/src/main.rs
+++ b/src/hardware/platform/stm32l552/boot/src/main.rs
@@ -26,8 +26,8 @@ use arm::mpu;
 use drivers::gtzc;
 use drivers::rcc;
 use drivers::uart;
-use drivers::uart::Uart;
 use drivers::gpio;
+#[cfg(feature = "boot_tests")]
 use drivers::aes::AesEngine;
 
 // Umbra Kernel-related crates
@@ -69,8 +69,9 @@ static mut CIPHERTEXT_BUF: [u8; OTFDEC_REGION_SIZE_BSS] = [0u8; OTFDEC_REGION_SI
 
 
 
+#[cfg(feature = "boot_tests")]
 #[inline(never)]
-fn print_hex(_uart: &Uart, val: u32) {
+fn print_hex(_uart: &uart::Uart, val: u32) {
     crate::raw_print::print_hex(val);
 }
 
@@ -101,7 +102,7 @@ pub unsafe fn secure_boot() -> !{
     
     // Initialize UART (LPUART1 for 552, USART1 for 562)
     let serial = uart::Uart::new_lpuart1_and_configure(9600);
-    
+
     serial.write("\n");
     serial.write("   ___       ___       ___       ___       ___   \n");
     serial.write("  /\\__\\     /\\__\\     /\\  \\     /\\  \\     /\\  \\  \n");
@@ -111,62 +112,65 @@ pub unsafe fn secure_boot() -> !{
     serial.write(" \\::/  /    /:/  /   \\::/  /   |:\\/__/    /:/  / \n");
     serial.write("  \\/__/     \\/__/     \\/__/     \\|__|     \\/__/  \n");
     serial.write("\n");
-    
 
     serial.write("[UMBRASecureBoot] Secure Boot started\n");
 
-    // Print Stack Sizes and Usage
-    let umb_stack_size_val = &_umb_stack_size as *const u32 as u32;
-    let umb_estack_val = &_umb_estack as *const u32 as u32;
-
-    // Calculate current stack usage (sp)
-    let sp: u32 = cortex_m::register::msp::read() as u32;
-    let used_stack = umb_estack_val - sp;
-    
-    // Attempting to print using simple hex loop to avoid trait issues if Uart doesn't implement it perfectly
-    serial.write("[UMBRASecureBoot] Stack Info:\n");
-    
-    serial.write("  _umb_stack_size: 0x");
-    print_hex(&serial, umb_stack_size_val);
-    serial.write("\n");
-
-    serial.write("  Current Secure Stack Usage: 0x");
-    print_hex(&serial, used_stack);
-    serial.write(" (SP: 0x");
-    print_hex(&serial, sp);
-    serial.write(")\n");
-    
-    let remaining_stack = umb_stack_size_val - used_stack;
-    serial.write("  Remaining Secure Stack: 0x");
-    print_hex(&serial, remaining_stack);
-    serial.write("\n");
-
-
-    serial.write("[UMBRASecureBoot] TEST HAL\n");
-
-    #[cfg(feature = "stm32l562")]
+    #[cfg(feature = "boot_tests")]
     {
-        gpio_led.pin_set(pin);
-        serial.write("[UMBRASecureBoot] TEST GPIO Active Low\n");
-        gpio_led.pin_reset(pin);
+        // Print Stack Sizes and Usage
+        let umb_stack_size_val = &_umb_stack_size as *const u32 as u32;
+        let umb_estack_val = &_umb_estack as *const u32 as u32;
+        let sp: u32 = cortex_m::register::msp::read() as u32;
+        let used_stack = umb_estack_val - sp;
+
+        serial.write("[UMBRASecureBoot] Stack Info:\n");
+        
+        serial.write("  _umb_stack_size: 0x");
+        print_hex(&serial, umb_stack_size_val);
+        serial.write("\n");
+
+        serial.write("  Current Secure Stack Usage: 0x");
+        print_hex(&serial, used_stack);
+        serial.write(" (SP: 0x");
+        print_hex(&serial, sp);
+        serial.write(")\n");
+        
+        let remaining_stack = umb_stack_size_val - used_stack;
+        serial.write("  Remaining Secure Stack: 0x");
+        print_hex(&serial, remaining_stack);
+        serial.write("\n");
     }
-    #[cfg(not(feature = "stm32l562"))]
+
+
+    #[cfg(feature = "boot_tests")]
     {
-        gpio_led.pin_reset(pin);
-        serial.write("[UMBRASecureBoot] TEST GPIO Active High\n");
-        gpio_led.pin_set(pin);
+        serial.write("[UMBRASecureBoot] TEST HAL\n");
+
+        #[cfg(feature = "stm32l562")]
+        {
+            gpio_led.pin_set(pin);
+            serial.write("[UMBRASecureBoot] TEST GPIO Active Low\n");
+            gpio_led.pin_reset(pin);
+        }
+        #[cfg(not(feature = "stm32l562"))]
+        {
+            gpio_led.pin_reset(pin);
+            serial.write("[UMBRASecureBoot] TEST GPIO Active High\n");
+            gpio_led.pin_set(pin);
+        }
     }
-    
 
     //////////////////////////////
     // INITIALIZE MEMORY GUARDS //
     //////////////////////////////
     
     let mut sau_driver : sau::SauDriver = sau::SauDriver::new();
+    #[cfg(feature = "boot_tests")]
     serial.write("[UMBRASecureBoot] SAU started\n");
 
     rcc.enable_clock(rcc::peripherals::GTZC);
     let mut gtzc_driver : gtzc::GtzcDriver = gtzc::GtzcDriver::new();
+    #[cfg(feature = "boot_tests")]
     serial.write("[UMBRASecureBoot] GTZC started\n");
 
     sau_driver.memory_security_guard_init();
@@ -181,17 +185,21 @@ pub unsafe fn secure_boot() -> !{
     {
         let shcsr = 0xE000ED24 as *mut u32;
         let before = core::ptr::read_volatile(shcsr);
-        serial.write("[UMBRASecureBoot] SHCSR before: 0x");
-        print_hex(&serial, before);
-        serial.write("\n");
+        #[cfg(feature = "boot_tests")]{
+            serial.write("[UMBRASecureBoot] SHCSR before: 0x");
+            print_hex(&serial, before);
+            serial.write("\n");
+        }
         // 16=MEMFAULTENA, 17=BUSFAULTENA, 18=USGFAULTENA, 19=SECUREFAULTENA.
         // Enabling BUS/USG prevents silent escalation so a misrouted fault
         // surfaces in its own handler instead of the HardFault sink.
         core::ptr::write_volatile(shcsr, before | (1 << 16) | (1 << 17) | (1 << 18) | (1 << 19));
-        let after = core::ptr::read_volatile(shcsr);
-        serial.write("[UMBRASecureBoot] SHCSR after:  0x");
-        print_hex(&serial, after);
-        serial.write("\n");
+        #[cfg(feature = "boot_tests")]{
+            let after = core::ptr::read_volatile(shcsr);
+            serial.write("[UMBRASecureBoot] SHCSR after:  0x");
+            print_hex(&serial, after);
+            serial.write("\n");
+        }
     }
 
     // Ensure UsageFault is always enabled (needed for enclave
@@ -215,7 +223,9 @@ pub unsafe fn secure_boot() -> !{
     // AP bits permit the write.
     mpu_driver.set_mair(0, 0xFF);
     mpu_driver.enable();
-    serial.write("[UMBRASecureBoot] MPU started\n");
+    #[cfg(feature = "boot_tests")]{    
+        serial.write("[UMBRASecureBoot] MPU started\n");
+    }
 
     // MPU Test: Configure Region 0 for 0x20008000 - 0x2000803F as RW
     let mut region_config = mpu::MpuRegionConfig::new();
@@ -226,11 +236,14 @@ pub unsafe fn secure_boot() -> !{
     region_config.sh = mpu::MpuShareability::NonShareable;
     region_config.xn = mpu::MpuExecuteNever::ExecutionPermitted;
     region_config.enable = true;
-    
-    mpu_driver.configure_region(&region_config);
-    serial.write("\t[UMBRASecureBoot] MPU Region 0 Configured: 0x20008000 (RW Priv)\n");
-    
-    
+
+        mpu_driver.configure_region(&region_config);
+        #[cfg(feature = "boot_tests")]
+        {
+            serial.write("\t[UMBRASecureBoot] MPU Region 0 Configured: 0x20008000 (RW Priv)\n");
+        }
+
+
     //////////////////////////////////////////////////
     // CONFIGURE NON-SECURE CODE - FLASH CONTROLLER //
     //////////////////////////////////////////////////
@@ -247,7 +260,10 @@ pub unsafe fn secure_boot() -> !{
     let mut memory_block_list = MemoryBlockList::create_from_range(0x08040000,0x08080000);
     memory_block_list.set_memory_block_security(MemoryBlockSecurityAttribute::Untrusted);
     sau_driver.memory_security_guard_create(&memory_block_list);
-    serial.write("\t[UMBRASecureBoot] Untrusted Memory Block Range: 0x08040000 - 0x08080000\n");
+    #[cfg(feature = "boot_tests")]
+    {
+        serial.write("\t[UMBRASecureBoot] Untrusted Memory Block Range: 0x08040000 - 0x08080000\n");
+    }
 
     /////////////////////////////////////
     // CONFIGURE NON-SECURE DATA - SAU //
@@ -281,7 +297,10 @@ pub unsafe fn secure_boot() -> !{
     memory_block_list = MemoryBlockList::create_from_range(0x20030000,0x2003E000);
     memory_block_list.set_memory_block_security(MemoryBlockSecurityAttribute::Trusted);
     gtzc_driver.memory_security_guard_create(&memory_block_list);
-    serial.write("\t[UMBRASecureBoot] Trusted Memory Block Range: 0x20020000 - 0x2003E000\n");
+    #[cfg(feature = "boot_tests")]
+    {
+        serial.write("\t[UMBRASecureBoot] Trusted Memory Block Range: 0x20020000 - 0x2003E000\n");
+    }
 
 
 
@@ -293,14 +312,20 @@ pub unsafe fn secure_boot() -> !{
     memory_block_list = MemoryBlockList::create_from_range(0x08030000,0x0803ffe0);
     memory_block_list.set_memory_block_security(MemoryBlockSecurityAttribute::TrustedGateway);
     sau_driver.memory_security_guard_create(&memory_block_list);
-    serial.write("\t[UMBRASecureBoot] Trusted Gateway Memory Block Range:0x08030000 - 0x0803ffe0\n");
+    #[cfg(feature = "boot_tests")]
+    {
+        serial.write("\t[UMBRASecureBoot] Trusted Gateway Memory Block Range:0x08030000 - 0x0803ffe0\n");
+    }
 
     /////////////////////////////////////
     // DMA Demo                        //
     /////////////////////////////////////
     rcc.enable_clock(rcc::peripherals::DMA1);
     rcc.enable_clock(rcc::peripherals::DMA2);
-    serial.write("[UMBRASecureBoot] TEST DMA\n");
+    #[cfg(feature = "boot_tests")]
+    {
+        serial.write("[UMBRASecureBoot] TEST DMA\n");
+    }
     
     // Enable NVIC for DMA1 Channel 1 (IRQ 29)
     // Enable NVIC for DMA1 Channels 1-4 (IRQ 29, 30, 31, 32)
@@ -325,70 +350,79 @@ pub unsafe fn secure_boot() -> !{
     memory_block_list = MemoryBlockList::create_from_range(0x40000000, 0x50000000);
     memory_block_list.set_memory_block_security(MemoryBlockSecurityAttribute::Untrusted);
     sau_driver.memory_security_guard_create(&memory_block_list);
-    serial.write("\t[UMBRASecureBoot] Untrusted Peripheral Range: 0x40000000 - 0x50000000\n");
+    #[cfg(feature = "boot_tests")]
+    {
+        serial.write("\t[UMBRASecureBoot] Untrusted Peripheral Range: 0x40000000 - 0x50000000\n");
+    }
 
 
     /////////////////////////////////////
     // HASH HMAC TEST                  //
     /////////////////////////////////////
-    serial.write("[UMBRASecureBoot] TEST HASH\n");
+    #[cfg(feature = "boot_tests")]
+    {
+        serial.write("[UMBRASecureBoot] TEST HASH\n");
 
-    use drivers::hash::{Hash, Algorithm, DataType};
-    let mut hash = Hash::new();
-    let key = "test".as_bytes();
-    let data = "ForzaNapoliSempre".as_bytes();
-    let mut ctx = hash.start(Algorithm::SHA256, DataType::Width8, Some(key));
-    hash.update(&mut ctx, data);
-    let mut digest = [0u8; 32];
-    hash.finish(ctx, &mut digest);
+        use drivers::hash::{Hash, Algorithm, DataType};
+        let mut hash = Hash::new();
+        let key = "test".as_bytes();
+        let data = "ForzaNapoliSempre".as_bytes();
+        let mut ctx = hash.start(Algorithm::SHA256, DataType::Width8, Some(key));
+        hash.update(&mut ctx, data);
+        let mut digest = [0u8; 32];
+        hash.finish(ctx, &mut digest);
 
-    serial.write("\t[HMAC] SHA256: ");
-    crate::raw_print::print_hex_bytes(&digest);
-    serial.write("\n");
-    
+        serial.write("\t[HMAC] SHA256: ");
+        crate::raw_print::print_hex_bytes(&digest);
+        serial.write("\n");
+    }
+
     /////////////////////////////////////
     // AES TEST                        //
     /////////////////////////////////////
-    serial.write("[UMBRASecureBoot] TEST AES\n");
+    #[cfg(feature = "boot_tests")]
     {
-        #[cfg(feature = "stm32l562")]
-        use drivers::aes::AesHardware as AesImpl;
+        serial.write("[UMBRASecureBoot] TEST AES\n");
+        {
+            #[cfg(feature = "stm32l562")]
+            use drivers::aes::AesHardware as AesImpl;
         
-        #[cfg(not(feature = "stm32l562"))]
-        use drivers::aes::AesEmulated as AesImpl;
+            #[cfg(not(feature = "stm32l562"))]
+            use drivers::aes::AesEmulated as AesImpl;
         
-        let mut aes = AesImpl::new();
-        let key: [u8; 16] = [0x2b, 0x7e, 0x15, 0x16, 0x28, 0xae, 0xd2, 0xa6, 0xab, 0xf7, 0x15, 0x88, 0x09, 0xcf, 0x4f, 0x3c];
-        let input: [u8; 16] = [0x6b, 0xc1, 0xbe, 0xe2, 0x2e, 0x40, 0x9f, 0x96, 0xe9, 0x3d, 0x7e, 0x11, 0x73, 0x93, 0x17, 0x2a];
-        let expected_ciphertext: [u8; 16] = [0x3a, 0xd7, 0x7b, 0xb4, 0x0d, 0x7a, 0x36, 0x60, 0xa8, 0x9e, 0xca, 0xf3, 0x24, 0x66, 0xef, 0x97];
+            let mut aes = AesImpl::new();
+            let key: [u8; 16] = [0x2b, 0x7e, 0x15, 0x16, 0x28, 0xae, 0xd2, 0xa6, 0xab, 0xf7, 0x15, 0x88, 0x09, 0xcf, 0x4f, 0x3c];
+            let input: [u8; 16] = [0x6b, 0xc1, 0xbe, 0xe2, 0x2e, 0x40, 0x9f, 0x96, 0xe9, 0x3d, 0x7e, 0x11, 0x73, 0x93, 0x17, 0x2a];
+            let expected_ciphertext: [u8; 16] = [0x3a, 0xd7, 0x7b, 0xb4, 0x0d, 0x7a, 0x36, 0x60, 0xa8, 0x9e, 0xca, 0xf3, 0x24, 0x66, 0xef, 0x97];
         
-        let mut output: [u8; 16] = [0; 16];
-        let mut check_decrypt: [u8; 16] = [0; 16];
+            let mut output: [u8; 16] = [0; 16];
+            let mut check_decrypt: [u8; 16] = [0; 16];
 
-        #[cfg(feature = "stm32l562")]
-        serial.write("\t[AES] Does AES-128 HW Test.. \n");
-        #[cfg(not(feature = "stm32l562"))]
-        serial.write("\t[AES] Does AES-128 SW Test.. \n");
+            #[cfg(feature = "stm32l562")]
+            serial.write("\t[AES] Does AES-128 HW Test.. \n");
+            #[cfg(not(feature = "stm32l562"))]
+            serial.write("\t[AES] Does AES-128 SW Test.. \n");
 
-        aes.init(&key, None);
-        aes.encrypt_block(&input, &mut output);
+            aes.init(&key, None);
+            aes.encrypt_block(&input, &mut output);
         
-        serial.write("\t[AES] Encrypted: ");
-        crate::raw_print::print_hex_bytes(&output);
-        serial.write("\n");
+            serial.write("\t[AES] Encrypted: ");
+            crate::raw_print::print_hex_bytes(&output);
+            serial.write("\n");
 
-        if output == expected_ciphertext {
-            serial.write("\t[AES] Encryption MATCH\n");
-        } else {
-             serial.write("\t[AES] Encryption FAIL\n");
-        }
+            if output == expected_ciphertext {
+                serial.write("\t[AES] Encryption MATCH\n");
+            } else {
+                serial.write("\t[AES] Encryption FAIL\n");
+            }
 
-        aes.decrypt_block(&output, &mut check_decrypt);
+            aes.decrypt_block(&output, &mut check_decrypt);
         
-        if check_decrypt == input {
-             serial.write("\t[AES] Decryption MATCH\n");
-        } else {
-             serial.write("\t[AES] Decryption FAIL\n");
+            if check_decrypt == input {
+                serial.write("\t[AES] Decryption MATCH\n");
+            } else {
+                serial.write("\t[AES] Decryption FAIL\n");
+            }
         }
     }
 
@@ -439,9 +473,11 @@ pub unsafe fn secure_boot() -> !{
         ospi.init();
         match ospi.enable_memory_mapped_octa() {
             Ok(()) => {
+                #[cfg(feature = "boot_tests")]
                 serial.write("[UMBRASecureBoot] OCTOSPI memory-mapped OK\n");
             }
             Err(msg) => {
+                #[cfg(feature = "boot_tests")]
                 serial.write("[UMBRASecureBoot] OCTOSPI FAIL: ");
                 serial.write(msg);
                 serial.write("\n");
@@ -586,6 +622,7 @@ pub unsafe fn secure_boot() -> !{
         let syst_csr = 0xE000_E010 as *mut u32;
         core::ptr::write_volatile(syst_csr, 0x00); // Ensure disabled
     }
+    #[cfg(feature = "boot_tests")]
     serial.write("[UMBRASecureBoot] SysTick configured (disabled)\n");
 
     /////////////////////////////////////

--- a/src/hardware/platform/stm32l552/boot/src/raw_print.rs
+++ b/src/hardware/platform/stm32l552/boot/src/raw_print.rs
@@ -54,6 +54,7 @@ pub fn print_hex(val: u32) {
 }
 
 /// Print a byte slice as lowercase hex (two chars per byte).
+#[cfg(feature = "boot_tests")]
 #[inline(never)]
 pub fn print_hex_bytes(data: &[u8]) {
     const HEX: &[u8; 16] = b"0123456789abcdef";

--- a/src/kernel/asm/arm/nsc_veneers.s
+++ b/src/kernel/asm/arm/nsc_veneers.s
@@ -16,17 +16,6 @@
         pop {r4, lr}
         bxns lr
 
-    .global umbra_enclave_run
-    .extern umbra_enclave_run_imp
-
-    .thumb_func
-    umbra_enclave_run:
-        sg
-        push {r4, lr}
-        bl umbra_enclave_run_imp
-        pop {r4, lr}
-        bxns lr
-
     .global umbra_debug_print
     .extern umbra_debug_print_imp
 

--- a/src/kernel/src/lib.rs
+++ b/src/kernel/src/lib.rs
@@ -11,4 +11,3 @@ pub mod panic;
 pub mod key_storage_server;
 
 pub use crate::umbra_nsc_api::umbra_tee_create;
-pub use crate::umbra_nsc_api::umbra_enclave_run;

--- a/src/kernel/src/umbra_nsc_api.rs
+++ b/src/kernel/src/umbra_nsc_api.rs
@@ -10,7 +10,6 @@
 #[cfg(all(target_arch = "arm", target_os = "none"))]
 extern "C" {
     pub fn umbra_tee_create(base_addr: u32) -> u32;
-    pub fn umbra_enclave_run();
     pub fn umbra_debug_print(str_ptr: *const u8);
     pub fn umbra_enclave_enter(enclave_id: u32) -> u32;
     pub fn umbra_enclave_exit(enclave_id: u32) -> u32;
@@ -20,7 +19,6 @@ extern "C" {
 #[cfg(all(target_arch = "arm", target_os = "none"))]
 extern "C" {
     pub fn umbra_tee_create_imp(base_addr: u32) -> u32;
-    pub fn umbra_enclave_run_imp() -> u32;
     pub fn umbra_debug_print_imp(str_ptr: *const u8);
     pub fn umbra_enclave_enter_imp(enclave_id: u32) -> u32;
     pub fn umbra_enclave_exit_imp(enclave_id: u32) -> u32;

--- a/tools/golden_uart.log
+++ b/tools/golden_uart.log
@@ -8,37 +8,9 @@
   \/__/     \/__/     \/__/     \|__|     \/__/  
 
 [UMBRASecureBoot] Secure Boot started
-[UMBRASecureBoot] Stack Info:
-  _umb_stack_size: 0x00004000
-  Current Secure Stack Usage: 0xF00023D8 (SP: 0x3003BC24)
-  Remaining Secure Stack: 0x10001C28
-[UMBRASecureBoot] TEST HAL
-[UMBRASecureBoot] TEST GPIO Active High
-[UMBRASecureBoot] SAU started
-[UMBRASecureBoot] GTZC started
-[UMBRASecureBoot] SHCSR before: 0x00000000
-[UMBRASecureBoot] SHCSR after:  0x000F0000
-[UMBRASecureBoot] MPU started
-	[UMBRASecureBoot] MPU Region 0 Configured: 0x20008000 (RW Priv)
-	[UMBRASecureBoot] Untrusted Memory Block Range: 0x08040000 - 0x08080000
-	[UMBRASecureBoot] Trusted Memory Block Range: 0x20020000 - 0x2003E000
-	[UMBRASecureBoot] Trusted Gateway Memory Block Range:0x08030000 - 0x0803ffe0
-[UMBRASecureBoot] TEST DMA
-	[UMBRASecureBoot] Untrusted Peripheral Range: 0x40000000 - 0x50000000
-[UMBRASecureBoot] TEST HASH
-	[HMAC] SHA256: f5e6d6015105a108e1b30921318b8555fe0636d1136c956c9d80b3a775cc48ad
-[UMBRASecureBoot] TEST AES
-	[AES] Does AES-128 SW Test.. 
-	[AES] Encrypted: 3ad77bb40d7a3660a89ecaf32466ef97
-	[AES] Encryption MATCH
-	[AES] Decryption MATCH
 [UMBRASecureBoot] Kernel Initialized
-[UMBRASecureBoot] SysTick configured (disabled)
 [UMBRASecureBoot] Jumping to Non-Secure World
 [USER] Hello Non-Secure World!
-[UMBRASecureBoot] chained-measurement OK
-[USER] Enclave 0 created
-[UMBRASecureBoot] ESS miss recovered
-[USER] Enclave preempted (SysTick)
-[USER] Enclave terminated
+[USER] Enclave created
+[USER] Enclave terminated! R0=0x72CA33A8
 [USER] All enclaves done

--- a/tools/golden_uart_l562.log
+++ b/tools/golden_uart_l562.log
@@ -1,4 +1,4 @@
-þ
+ï¿½
    ___       ___       ___       ___       ___   
   /\__\     /\__\     /\  \     /\  \     /\  \  
  /:/ _/_   /::L_L_   /::\  \   /::\  \   /::\  \ 
@@ -8,38 +8,9 @@
   \/__/     \/__/     \/__/     \|__|     \/__/  
 
 [UMBRASecureBoot] Secure Boot started
-[UMBRASecureBoot] Stack Info:
-  _umb_stack_size: 0x00004000
-  Current Secure Stack Usage: 0xF00018C8 (SP: 0x3003C734)
-  Remaining Secure Stack: 0x10002738
-[UMBRASecureBoot] TEST HAL
-[UMBRASecureBoot] TEST GPIO Active Low
-[UMBRASecureBoot] SAU started
-[UMBRASecureBoot] GTZC started
-[UMBRASecureBoot] SHCSR before: 0x00000000
-[UMBRASecureBoot] SHCSR after:  0x000F0000
-[UMBRASecureBoot] MPU started
-	[UMBRASecureBoot] MPU Region 0 Configured: 0x20008000 (RW Priv)
-	[UMBRASecureBoot] Untrusted Memory Block Range: 0x08040000 - 0x08080000
-	[UMBRASecureBoot] Trusted Memory Block Range: 0x20020000 - 0x2003E000
-	[UMBRASecureBoot] Trusted Gateway Memory Block Range:0x08030000 - 0x0803ffe0
-[UMBRASecureBoot] TEST DMA
-	[UMBRASecureBoot] Untrusted Peripheral Range: 0x40000000 - 0x50000000
-[UMBRASecureBoot] TEST HASH
-	[HMAC] SHA256: f5e6d6015105a108e1b30921318b8555fe0636d1136c956c9d80b3a775cc48ad
-[UMBRASecureBoot] TEST AES
-	[AES] Does AES-128 HW Test.. 
-	[AES] Encrypted: 3ad77bb40d7a3660a89ecaf32466ef97
-	[AES] Encryption MATCH
-	[AES] Decryption MATCH
 [UMBRASecureBoot] Kernel Initialized
-[UMBRASecureBoot] OCTOSPI memory-mapped OK
-[UMBRASecureBoot] SysTick configured (disabled)
 [UMBRASecureBoot] Jumping to Non-Secure World
 [USER] Hello Non-Secure World!
-[UMBRASecureBoot] chained-measurement OK
-[USER] Enclave 0 created
-[UMBRASecureBoot] ESS miss recovered
-[USER] Enclave preempted (SysTick)
-[USER] Enclave terminated
+[USER] Enclave created
+[USER] Enclave terminated! R0=0x72CA33A8
 [USER] All enclaves done

--- a/tools/smoke_test.sh
+++ b/tools/smoke_test.sh
@@ -1,4 +1,4 @@
-#!/bin/zsh
+#!/usr/bin/env bash
 # T3 smoke-test harness.
 # Prereqs: `make openocd` running in another shell (telnet port 4444 reachable).
 #
@@ -22,7 +22,7 @@ set -uo pipefail
 # process input as raw bytes.
 export LC_ALL=C
 
-UART="${UMBRA_UART:?Set UMBRA_UART to the target's serial device}"
+UART="${UMBRA_UART:?Set UMBRA_UART to the target serial device}"
 OOCD_HOST="${UMBRA_OOCD_HOST:-localhost}"
 OOCD_TELNET_PORT="${UMBRA_OOCD_TELNET_PORT:-4444}"
 LOG="tools/last_uart.log"
@@ -73,14 +73,8 @@ fi
 # mask 0xHEX on lines whose content matches the drift-allowed patterns below.
 # Add more patterns here if other lines prove volatile.
 normalize() {
-    sed -E '
-        /_umb_stack_size:/           s/0x[0-9A-Fa-f]+/0xDRIFT/g
-        /Current Secure Stack Usage:/ s/0x[0-9A-Fa-f]+/0xDRIFT/g
-        /Remaining Secure Stack:/    s/0x[0-9A-Fa-f]+/0xDRIFT/g
-        /SHCSR before:/              s/0x[0-9A-Fa-f]+/0xDRIFT/g
-        /SHCSR after:/               s/0x[0-9A-Fa-f]+/0xDRIFT/g
-        s| //ALLOW_DRIFT$||
-    ' "$1" \
+    tr -d '\200-\377' < "$1" \
+    | sed -E -e '/_umb_stack_size:/s/0x[0-9A-Fa-f]+/0xDRIFT/g' -e '/Current Secure Stack Usage:/s/0x[0-9A-Fa-f]+/0xDRIFT/g' -e '/Remaining Secure Stack:/s/0x[0-9A-Fa-f]+/0xDRIFT/g' -e '/SHCSR before:/s/0x[0-9A-Fa-f]+/0xDRIFT/g' -e '/SHCSR after:/s/0x[0-9A-Fa-f]+/0xDRIFT/g' -e 's| //ALLOW_DRIFT$||' \
     | awk '/\[USER\] Enclave preempted/ { if (!seen_preempt) { print; seen_preempt=1 } next } { seen_preempt=0; print }' \
     | awk '{ lines[NR]=$0 } /[^ \t]/{last=NR} END{ for(i=1;i<=last;i++) print lines[i] }'
 }

--- a/tools/smoke_test_fault.sh
+++ b/tools/smoke_test_fault.sh
@@ -1,4 +1,4 @@
-#!/bin/zsh
+#!/usr/bin/env bash
 # Fault-injection harness
 #
 # Flow (STM32L5 with TZEN=1 can't write flash at runtime via openocd, so we
@@ -23,7 +23,7 @@
 
 set -uo pipefail
 
-UART="${UMBRA_UART:?Set UMBRA_UART to the target's serial device}"
+UART="${UMBRA_UART:?Set UMBRA_UART to the target serial device}"
 OOCD_HOST="${UMBRA_OOCD_HOST:-localhost}"
 OOCD_TELNET_PORT="${UMBRA_OOCD_TELNET_PORT:-4444}"
 OOCD_GDB_PORT="${UMBRA_OOCD_GDB_PORT:-3333}"

--- a/tools/smoke_test_fault_runtime.sh
+++ b/tools/smoke_test_fault_runtime.sh
@@ -1,4 +1,4 @@
-#!/bin/zsh
+#!/usr/bin/env bash
 # Runtime ESS-miss fault-injection harness
 #
 # Exercises three attack cases from UmbraIntegrityFixValidator.pv (L552) /
@@ -32,7 +32,7 @@
 
 set -uo pipefail
 
-UART="${UMBRA_UART:?Set UMBRA_UART to the target's serial device}"
+UART="${UMBRA_UART:?Set UMBRA_UART to the target serial device}"
 OOCD_HOST="${UMBRA_OOCD_HOST:-localhost}"
 OOCD_TELNET_PORT="${UMBRA_OOCD_TELNET_PORT:-4444}"
 OOCD_GDB_PORT="${UMBRA_OOCD_GDB_PORT:-3333}"


### PR DESCRIPTION
Issue #29: Remove legacy code and update smoke tests.

Legacy removal:
- Remove umbra_enclave_run NSC veneer, declarations, implementation, and linker entries (replaced by enclave_enter/exit in Phase 4)
- Recalculate NSC veneer addresses in host.ld (6→5 veneers)
- Remove extern declaration from host main.c

boot_tests feature (OFF by default):
- Gate diagnostic sections: stack info, GPIO/HAL test, HASH HMAC test, AES encrypt/decrypt test, MPU Region 0 test config
- Gate associated imports and helpers (AesEngine, print_hex, print_hex_bytes)
- Saves ~794 bytes .rodata + associated code in production builds
- Enable with: cargo build --features boot_tests

Smoke test fixes:
- Shebang #!/bin/zsh → #!/usr/bin/env bash for Linux portability
- Fix apostrophe in ${UMBRA_UART:?} message (bash parse error)
- Add tr high-byte stripping for L562 boot ROM 0xFE normalization
- Convert sed multiline to -e flags for bash compatibility
- Update golden logs to match default build (no boot_tests)

Documentation:
- Update book: 6→5 NSC veneers, UART output matches new golden