### PR TITLE
feat: add minimal FreeRTOS demo in Non-Secure world (#31)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@
 # Ignore build artifacts
 lib/*
 
+# Explicitly track FreeRTOS-Kernel submodule despite lib/* rule
+!host/freertos_arm/lib/FreeRTOS-Kernel
+
 # Ignore deprecated
 deprecated
 
@@ -15,6 +18,8 @@ todo
 # Ignore builds for bare_metal_arm
 host/bare_metal_arm/bin/*
 host/bare_metal_arm/obj/*
+host/freertos_arm/bin/*
+host/freertos_arm/obj/*
 
 # T3 smoke-test transient output (golden_uart.log is tracked)
 tools/last_uart.log

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "host/freertos_arm/lib/FreeRTOS-Kernel"]
+	path = host/freertos_arm/lib/FreeRTOS-Kernel
+	url = https://github.com/FreeRTOS/FreeRTOS-Kernel.git

--- a/Makefile
+++ b/Makefile
@@ -118,8 +118,8 @@ program_elf_boot:
 
 program_elf_host:
 	$(GDB) $(HOST_ELF) \
-	-ex 'directory host/bare_metal_arm/src' \
-	-ex 'directory host/bare_metal_arm/app' \
+	-ex 'directory $(HOST_DIR)/src' \
+	-ex 'directory $(HOST_DIR)/app' \
 	-ex 'directory $(KERNEL_DIR)/src' \
 	-ex 'directory $(SECBOOT_DIR)/src' \
 	-ex 'directory $(PLATFORM_DIR)/drivers/src' \
@@ -160,9 +160,9 @@ program_target: enable_security
 # (OTFDEC ENC-mode + OCTOSPI PP) to overwrite it with the real ciphertext
 # in place on first boot. There is no offline encryptor.
 program_enclaves_extload:
-	$(MAKE) -C host/bare_metal_arm enclaves_plain.bin
+	$(MAKE) -C $(HOST_DIR) enclaves_plain.bin
 	$(FLASHER) $(CONNECT) --extload $(EXTLOAD_STLDR) \
-		--download host/bare_metal_arm/enclaves_plain.bin 0x90000000 -v
+		--download $(HOST_DIR)/enclaves_plain.bin 0x90000000 -v
 
 #########
 # PHONY #

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -10,6 +10,12 @@
 - [Build and Run](getting-started/build-and-run.md)
 - [Hardware Setup](getting-started/hardware-setup.md)
 
+# Host Examples
+
+- [Overview](examples/README.md)
+- [Bare-Metal](examples/bare-metal.md)
+- [FreeRTOS](examples/freertos.md)
+
 # Architecture
 
 - [Overview](architecture/overview.md)

--- a/book/src/examples/README.md
+++ b/book/src/examples/README.md
@@ -1,0 +1,35 @@
+# Host Examples
+
+Umbra ships with two Non-Secure host applications that demonstrate enclave lifecycle management through the NSC API. Both are self-contained C projects under `host/` with their own Makefile, linker scripts, and startup code.
+
+| Example | Path | Scheduler | Use case |
+|---|---|---|---|
+| [Bare-Metal](bare-metal.md) | `host/bare_metal_arm/` | Hand-rolled round-robin | Minimal footprint, no dependencies |
+| [FreeRTOS](freertos.md) | `host/freertos_arm/` | FreeRTOS V11.1.0 preemptive | RTOS coexistence proof |
+
+## Selecting an Example
+
+The active host is controlled by the `HOST_APP` environment variable:
+
+```bash
+# Bare-metal (default)
+source ./settings.sh
+./rebuild_all.sh
+./debug.sh
+
+# FreeRTOS
+export HOST_APP=freertos
+source ./settings.sh
+./rebuild_all.sh
+./debug.sh
+```
+
+`settings.sh` maps `HOST_APP` to the corresponding directory and exports `HOST_DIR`, `HOST_NAME`, and `HOST_ELF`. These variables are consumed by `rebuild_all.sh`, `debug.sh`, and the root Makefile targets (`program_elf_host`, `program_enclaves_extload`).
+
+## Common Enclave Payload
+
+Both examples use the same Fibonacci enclave (`app/fibonacci.c`). The enclave code is linked into the `._enclave_code` section, then encrypted and HMAC-signed by `tools/protect_enclave.py` at build time. At runtime, the Secure kernel validates and loads the enclave into the Enclave Swap Space (ESS) in Secure SRAM.
+
+## UART Output
+
+Connect to the ST-Link UART at **9600 baud**. Both examples print status messages prefixed with `[USER]` (bare-metal) or `[FREERTOS]` (FreeRTOS).

--- a/book/src/examples/bare-metal.md
+++ b/book/src/examples/bare-metal.md
@@ -1,0 +1,68 @@
+# Bare-Metal Example
+
+The bare-metal host (`host/bare_metal_arm/`) is the simplest way to interact with Umbra. It runs a hand-coded round-robin loop that scans flash for enclaves, creates them via NSC veneers, and executes them until termination.
+
+## How It Works
+
+```
+main()
+  ├── Scan NS flash (0x08040000–0x08080000) for UMBR magic at 4KB page boundaries
+  ├── umbra_tee_create(addr) for each enclave found
+  └── Round-robin loop:
+        ├── umbra_enclave_enter(id) → returns status
+        │     ├── SUSPENDED  → enclave was preempted by Secure SysTick
+        │     ├── TERMINATED → print R0 result, mark done
+        │     └── FAULTED    → print error, mark done
+        └── Repeat until all enclaves done
+```
+
+No RTOS, no heap, no interrupts in the NS world. The Secure SysTick handles enclave preemption; the host just re-enters suspended enclaves.
+
+## Building and Running
+
+```bash
+# Bare-metal is the default — no HOST_APP needed
+source ./settings.sh
+./rebuild_all.sh
+./debug.sh
+```
+
+## Expected UART Output
+
+```
+[UMBRASecureBoot] Secure Boot started
+[UMBRASecureBoot] Kernel Initialized
+[UMBRASecureBoot] Jumping to Non-Secure World
+[USER] Hello Non-Secure World!
+[USER] Enclave created
+[USER] Enclave preempted (SysTick)
+[USER] Enclave preempted (SysTick)
+...
+[USER] Enclave terminated! R0=0x72CA33A8
+[USER] All enclaves done
+```
+
+The number of `Enclave preempted` lines varies depending on the SysTick quantum (~10ms at 4 MHz MSI).
+
+## File Structure
+
+```
+host/bare_metal_arm/
+  ├── src/
+  │   ├── main.c          Entry point, enclave header, round-robin scheduler
+  │   └── startup.s       NS vector table + Reset_Handler (.data/.bss init)
+  ├── app/
+  │   └── fibonacci.c     Enclave payload (Fibonacci + filler functions)
+  ├── inc/
+  │   └── fibonacci.h
+  ├── linker/
+  │   ├── memory.ld       MCU memory regions + Umbra aliases
+  │   └── host.ld         Section layout + NSC veneer addresses (PROVIDE)
+  └── Makefile
+```
+
+## Key Design Points
+
+- **No vector table fetch**: the NS VTOR is not used at runtime — the bare-metal host never triggers SVC, PendSV, or SysTick exceptions. All scheduling is done cooperatively via the round-robin loop.
+- **Enclave header in flash**: the 48-byte header (magic, trust level, HMAC) is placed in `._enclave_header` by a section attribute. `protect_enclave.py` overwrites the HMAC field at build time.
+- **NSC veneer addresses**: hardcoded via `PROVIDE()` in `host.ld`. These must be updated if the Secure boot is rebuilt and veneer offsets change.

--- a/book/src/examples/freertos.md
+++ b/book/src/examples/freertos.md
@@ -1,0 +1,116 @@
+# FreeRTOS Example
+
+The FreeRTOS host (`host/freertos_arm/`) demonstrates that Umbra's TrustZone isolation works transparently with a standard RTOS. A single FreeRTOS task manages the entire enclave lifecycle, proving that the Secure SysTick (enclave preemption) and the NS SysTick (FreeRTOS tick) operate independently on the dual-SysTick Cortex-M33 architecture.
+
+## How It Works
+
+```
+main()
+  ├── Set VTOR to SRAM vector table
+  ├── Enable NS fault handlers (SHCSR)
+  ├── xTaskCreate(vEnclaveTask, ...)
+  └── vTaskStartScheduler()        // never returns
+
+vEnclaveTask(pvParameters)
+  ├── Scan NS flash for enclave headers (same logic as bare-metal)
+  ├── umbra_tee_create(addr) for each enclave found
+  ├── Loop: umbra_enclave_enter(id)
+  │     ├── SUSPENDED  → print, re-enter
+  │     ├── TERMINATED → print R0, mark done
+  │     └── FAULTED    → print error, mark done
+  └── vTaskDelete(NULL)            // self-delete when all done
+```
+
+FreeRTOS manages task scheduling in the NS world. The enclave task calls into the Secure kernel via NSC veneers — Umbra doesn't know or care that an RTOS is running.
+
+## Building and Running
+
+```bash
+export HOST_APP=freertos
+source ./settings.sh
+./rebuild_all.sh
+./debug.sh
+```
+
+The first build will clone the FreeRTOS-Kernel submodule automatically if needed:
+
+```bash
+git submodule update --init host/freertos_arm/lib/FreeRTOS-Kernel
+```
+
+## Expected UART Output
+
+```
+[UMBRASecureBoot] Secure Boot started
+[UMBRASecureBoot] Kernel Initialized
+[UMBRASecureBoot] Jumping to Non-Secure World
+[FREERTOS] Starting FreeRTOS demo
+[FREERTOS] Enclave task started
+[FREERTOS] Enclave created
+[FREERTOS] Enclave terminated! R0=0x72CA33A8
+[FREERTOS] All enclaves done
+```
+
+## File Structure
+
+```
+host/freertos_arm/
+  ├── lib/
+  │   └── FreeRTOS-Kernel/    Git submodule (V11.1.0, ARM_CM33_NTZ port)
+  ├── src/
+  │   ├── main.c              FreeRTOS init + enclave task
+  │   ├── vectors.c           SRAM vector table (aligned 512B, non-const)
+  │   ├── handlers.c          NS fault handlers (in C for Thumb bit correctness)
+  │   ├── port_overrides.c    vStartFirstTask override (avoids flash data read)
+  │   ├── startup.s           Reset_Handler only (.data/.bss init)
+  │   ├── mem.c               Minimal memset/memcpy for -nostdlib
+  │   └── FreeRTOSConfig.h    Kernel config (NTZ, 4MHz, 32KB heap)
+  ├── app/
+  │   └── fibonacci.c         Enclave payload (same as bare-metal)
+  ├── inc/
+  │   └── fibonacci.h
+  ├── linker/
+  │   ├── memory.ld           Self-contained memory regions + Umbra aliases
+  │   └── host.ld             Section layout + NSC veneer PROVIDE addresses
+  └── Makefile                Standalone build (FreeRTOS sources compiled from submodule)
+```
+
+## FreeRTOS Configuration
+
+| Parameter | Value | Rationale |
+|---|---|---|
+| `configCPU_CLOCK_HZ` | 4 MHz | MSI default clock |
+| `configTICK_RATE_HZ` | 1000 | 1ms tick |
+| `configTOTAL_HEAP_SIZE` | 32 KB | From SRAM_0 (128KB total) |
+| `configENABLE_TRUSTZONE` | 0 | NTZ port — Secure context managed by Umbra |
+| `configENABLE_MPU` | 0 | MPU managed by Umbra Secure side |
+| `configENABLE_FPU` | 0 | No floating point in demo |
+| `configCHECK_FOR_STACK_OVERFLOW` | 2 | Canary + watermark check |
+
+## TrustZone Porting Notes
+
+Porting FreeRTOS to the NS world of an STM32L5 with an active Secure kernel required solving several non-obvious issues:
+
+### SRAM Vector Table
+
+The STM32L5 IDAU classifies `0x08040000` (NS flash) as Secure for **data reads**. The SAU override only applies to instruction fetch. Since the Cortex-M33 vector table fetch is architecturally a data read, the NS vector table must reside in SRAM (`0x20000000+`), not flash.
+
+The vector table is defined as a non-const C array with `__attribute__((aligned(512)))`. It lands in `.data` and is copied to SRAM by the startup code. VTOR_NS is set to `0x20000000` by the Secure boot.
+
+### vStartFirstTask Override
+
+The FreeRTOS `ARM_CM33_NTZ` port reads `*(VTOR[0])` (a data read from the vector table base) to reset MSP. This faults on STM32L5 if VTOR points to flash. `port_overrides.c` provides a replacement that loads MSP from the linker symbol `_host_estack` instead.
+
+The override uses `--allow-multiple-definition` in LDFLAGS, with our object listed before FreeRTOS objects in link order.
+
+### SVC Number
+
+FreeRTOS V11 uses **SVC #102** (not #0) for `START_SCHEDULER`, defined in `portmacrocommon.h`. The override must use the correct number or the SVC handler ignores the call.
+
+### Fault Handlers in C
+
+Assembly-defined `.thumb_func` labels lose the Thumb interworking bit (LSB) in `R_ARM_ABS32` data relocations used by the SRAM vector table initializer. Defining fault handlers in C guarantees correct Thumb bit propagation.
+
+### NS Fault Handler Enable
+
+The Secure boot enables Secure SHCSR but not NS SHCSR. Without `SCB_SHCSR |= (1<<16)|(1<<17)|(1<<18)` in NS code, all configurable NS faults silently escalate to HardFault with no diagnostic CFSR bits.

--- a/book/src/getting-started/build-and-run.md
+++ b/book/src/getting-started/build-and-run.md
@@ -10,6 +10,21 @@ source settings.sh
 
 The script auto-detects the target MCU (STM32L552 or STM32L562) and configures paths, flash addresses, and feature flags.
 
+## Select Host Application
+
+Umbra ships with two NS host examples. Select one before building:
+
+```bash
+# Bare-metal round-robin (default)
+source ./settings.sh
+
+# FreeRTOS RTOS demo
+export HOST_APP=freertos
+source ./settings.sh
+```
+
+See the [Host Examples](../examples/README.md) section for details on each.
+
 ## Build Everything
 
 ```bash
@@ -21,7 +36,7 @@ This performs a full clean build:
 1. Generates a fresh master key (`tools/master_key.bin`)
 2. Builds the Secure Boot ELF (`secureboot_build` + `secureboot_bin`)
 3. Builds the Umbra kernel static library (`lib/libumbra.a`)
-4. Builds the host application (C, linked against `libumbra.a`)
+4. Builds the selected host application (`HOST_APP`, default: `bare_metal`)
 5. Protects enclave binaries (encryption, HMAC signing via `tools/protect_enclave.py`)
 
 ## Flash and Run

--- a/book/src/introduction.md
+++ b/book/src/introduction.md
@@ -34,11 +34,13 @@ Umbra supports creating TEEs from a bare-metal host with:
 ```
 umbra/
   src/
-    kernel/          # Architecture-agnostic kernel (enclave management, key storage)
+    kernel/               # Architecture-agnostic kernel (enclave management, key storage)
     hardware/
       architecture/arm/   # ARM Cortex-M33 primitives (SAU, MPU, vector table)
       platform/stm32l552/ # STM32L5 platform (boot, drivers)
-  host/bare_metal_arm/    # Example non-secure host application
+  host/
+    bare_metal_arm/       # Bare-metal NS host (round-robin enclave scheduler)
+    freertos_arm/         # FreeRTOS NS host (RTOS coexistence demo)
   tools/                  # Enclave protection, key generation, smoke tests
   linker/                 # Kernel linker scripts
   book/                   # This documentation (mdBook)

--- a/host/freertos_arm/Makefile
+++ b/host/freertos_arm/Makefile
@@ -1,0 +1,149 @@
+# FreeRTOS NS host demo for Umbra / STM32L552
+# Issue #31 — https://github.com/HiSA-Team/umbra/issues/31
+
+################
+# Program Name #
+################
+
+PROGRAM_NAME = $(shell basename $(dir $(abspath $(firstword $(MAKEFILE_LIST)))))
+
+#####################
+# Paths and Folders #
+#####################
+
+SRC_DIR     = src
+OBJ_DIR     = obj
+APP_DIR     = app
+INC_DIR     = inc
+STARTUP_DIR = src
+
+# FreeRTOS paths (V11.1.0: port files are in non_secure/ subdirectory)
+FREERTOS_DIR    = lib/FreeRTOS-Kernel
+FREERTOS_PORT   = $(FREERTOS_DIR)/portable/GCC/ARM_CM33_NTZ/non_secure
+FREERTOS_HEAP   = $(FREERTOS_DIR)/portable/MemMang
+
+LD_SCRIPTS = linker/memory.ld ../../linker/umbra.ld linker/host.ld
+
+#############
+# Toolchain #
+#############
+
+CC_PREFIX   = arm-none-eabi-
+CC          = $(CC_PREFIX)gcc
+LD          = $(CC_PREFIX)ld
+OBJDUMP     = $(CC_PREFIX)objdump
+OBJCOPY     = $(CC_PREFIX)objcopy
+
+CFLAGS      = -O0 -march=armv8-m.main -g -c -save-temps=obj -fverbose-asm -Wa,-L
+CFLAGS     += -I$(INC_DIR) -I$(SRC_DIR)
+CFLAGS     += -I$(FREERTOS_DIR)/include -I$(FREERTOS_PORT)
+
+LDFLAGS     = -nostdlib $(addprefix -T,$(LD_SCRIPTS)) --discard-none --allow-multiple-definition
+
+########
+# Srcs #
+########
+
+# Application sources
+APP_SRCS    = $(wildcard $(SRC_DIR)/*.c) $(wildcard $(APP_DIR)/*.c)
+APP_OBJS    = $(addprefix $(OBJ_DIR)/, $(notdir $(APP_SRCS:.c=.o)))
+
+# FreeRTOS sources
+FREERTOS_SRCS = $(FREERTOS_DIR)/tasks.c \
+                $(FREERTOS_DIR)/queue.c \
+                $(FREERTOS_DIR)/list.c \
+                $(FREERTOS_PORT)/port.c \
+                $(FREERTOS_PORT)/portasm.c \
+                $(FREERTOS_HEAP)/heap_4.c
+
+FREERTOS_OBJS = $(addprefix $(OBJ_DIR)/freertos_, $(notdir $(FREERTOS_SRCS:.c=.o)))
+
+ALL_OBJS = $(APP_OBJS) $(FREERTOS_OBJS) $(OBJ_DIR)/startup.o
+
+RM      = rm -rf
+MKDIR   = @mkdir -p $(@D)
+
+###########
+# Targets #
+###########
+
+all: bin/$(PROGRAM_NAME).bin
+
+# App sources
+$(OBJ_DIR)/%.o: $(SRC_DIR)/%.c
+	@echo "\n[OBJ]	Compiling $<"
+	$(MKDIR)
+	$(CC) -o $@ $^ $(CFLAGS)
+
+$(OBJ_DIR)/%.o: $(APP_DIR)/%.c
+	@echo "\n[OBJ]	Compiling $<"
+	$(MKDIR)
+	$(CC) -o $@ $^ $(CFLAGS)
+
+# FreeRTOS core
+$(OBJ_DIR)/freertos_tasks.o: $(FREERTOS_DIR)/tasks.c
+	$(MKDIR)
+	$(CC) -o $@ $^ $(CFLAGS)
+
+$(OBJ_DIR)/freertos_queue.o: $(FREERTOS_DIR)/queue.c
+	$(MKDIR)
+	$(CC) -o $@ $^ $(CFLAGS)
+
+$(OBJ_DIR)/freertos_list.o: $(FREERTOS_DIR)/list.c
+	$(MKDIR)
+	$(CC) -o $@ $^ $(CFLAGS)
+
+# FreeRTOS port
+$(OBJ_DIR)/freertos_port.o: $(FREERTOS_PORT)/port.c
+	$(MKDIR)
+	$(CC) -o $@ $^ $(CFLAGS)
+
+$(OBJ_DIR)/freertos_portasm.o: $(FREERTOS_PORT)/portasm.c
+	$(MKDIR)
+	$(CC) -o $@ $^ $(CFLAGS)
+
+# FreeRTOS heap
+$(OBJ_DIR)/freertos_heap_4.o: $(FREERTOS_HEAP)/heap_4.c
+	$(MKDIR)
+	$(CC) -o $@ $^ $(CFLAGS)
+
+# Startup
+$(OBJ_DIR)/startup.o: $(STARTUP_DIR)/startup.s
+	@echo "\n[OBJ]	Assembling $<"
+	$(MKDIR)
+	$(CC) -o $@ $^ $(CFLAGS)
+
+# Link
+bin/$(PROGRAM_NAME).elf: $(ALL_OBJS)
+	@echo "\n[ELF]	Linking $@"
+	$(MKDIR)
+	$(LD) -o $@ $^ $(LDFLAGS)
+
+# Protect enclave + create binary
+ifeq ($(MCU_VARIANT),stm32l562)
+PROTECT_ENCLAVE_FLAGS := --hmac-over-plaintext
+else
+PROTECT_ENCLAVE_FLAGS :=
+endif
+
+bin/$(PROGRAM_NAME).bin: bin/$(PROGRAM_NAME).elf
+	@echo "\n[BIN]	Creating binary"
+	@python3 ../../tools/protect_enclave.py $(PROTECT_ENCLAVE_FLAGS) bin/$(PROGRAM_NAME).elf src/main.c ../../tools/master_key.bin obj
+	$(OBJCOPY) -O binary bin/$(PROGRAM_NAME).elf bin/$(PROGRAM_NAME).bin
+
+ifeq ($(MCU_VARIANT),stm32l562)
+enclaves_plain.bin: bin/$(PROGRAM_NAME).bin
+	$(OBJCOPY) -O binary \
+		--only-section=._enclave_header \
+		--only-section=._enclave_code \
+		bin/$(PROGRAM_NAME).elf $@
+endif
+
+clean:
+	-$(RM) obj
+	-$(RM) bin
+
+dump:
+	$(OBJDUMP) -D bin/$(PROGRAM_NAME).elf
+
+.PHONY: all clean dump

--- a/host/freertos_arm/app/fibonacci.c
+++ b/host/freertos_arm/app/fibonacci.c
@@ -1,0 +1,80 @@
+#include "fibonacci.h"
+
+// Demo enclave payload. Linked into `.app.enclave_code` and loaded by secure
+// boot via the EFB pipeline. `fibonacci()` returns 1925854120; the
+// `dummy_filler_*` functions exist only to push the code size past one EFB
+// block so the multi-block loader path gets exercised.
+
+// Section attribute for all enclave code
+#define ENCLAVE_CODE __attribute__((section(".app.enclave_code")))
+
+int fibonacci() ENCLAVE_CODE;
+int heavy_computation(int val) ENCLAVE_CODE;
+void dummy_filler_A(int *val) ENCLAVE_CODE;
+void dummy_filler_B(int *val) ENCLAVE_CODE;
+void dummy_filler_C(int *val) ENCLAVE_CODE;
+
+// A large function to consume space (approx 100+ bytes)
+int heavy_computation(int val) {
+  volatile int x = val;
+  x = x * 1664525 + 1013904223;
+  x = (x << 13) ^ x;
+  x = x * 1664525 + 1013904223;
+  if (x % 2 == 0)
+    x += 1;
+  else
+    x -= 1;
+  x = x * 1664525 + 1013904223;
+  x = (x << 13) ^ x;
+  return x;
+}
+
+// Filler to push code size
+void dummy_filler_A(int *val) {
+  *val += 1;
+  *val = heavy_computation(*val);
+  *val ^= 0xAAAAAAAA;
+  *val = heavy_computation(*val);
+}
+
+void dummy_filler_B(int *val) {
+  *val += 2;
+  *val = heavy_computation(*val);
+  *val ^= 0x55555555;
+  *val = heavy_computation(*val);
+}
+
+void dummy_filler_C(int *val) {
+  *val += 3;
+  *val = heavy_computation(*val);
+  *val ^= 0xFF00FF00;
+  *val = heavy_computation(*val);
+}
+
+int fibonacci() {
+  int n = 12;
+  int t1 = 0, t2 = 1;
+  int nextTerm = t1 + t2;
+
+  // Call functions that are likely in different blocks due to size
+  t1 = heavy_computation(t1);
+  dummy_filler_A(&t1);
+
+  t2 = heavy_computation(t2);
+  dummy_filler_B(&t2);
+
+  for (int i = 3; i <= n; ++i) {
+    t1 = t2;
+    t2 = nextTerm;
+
+    // More calls inside loop
+    dummy_filler_C(&t1);
+
+    if (t1 > 100000)
+      t1 = 0; // Prevent overflow
+
+    nextTerm = t1 + t2;
+  }
+
+  return nextTerm; // Expected : 1925854120
+}

--- a/host/freertos_arm/inc/fibonacci.h
+++ b/host/freertos_arm/inc/fibonacci.h
@@ -1,0 +1,2 @@
+
+int fibonacci();

--- a/host/freertos_arm/linker/host.ld
+++ b/host/freertos_arm/linker/host.ld
@@ -1,0 +1,84 @@
+/*
+ * Sections layout for FreeRTOS NS host demo.
+ * FreeRTOS allocates per-task stacks from heap_4 in .bss.
+ * MSP stack is ISR-only (4KB is sufficient).
+ */
+
+ENTRY(_host_Reset_Handler)
+
+_host_stack_size = 0x1000;
+_host_estack = ORIGIN(SRAM_0) + LENGTH(SRAM_0) - 0x4;
+_host_sstack = _host_estack - _host_stack_size;
+
+_host_app_address = ORIGIN(FLASH_BANK_1) + LENGTH(FLASH_BANK_1) - 0x8000;
+
+SECTIONS
+{
+    /* FreeRTOS needs a valid VTOR — vectors must start at a naturally
+     * aligned address (no 0x20 skip like bare_metal_arm).  VTOR is set
+     * in startup.s to _host_vector_base. */
+    ._host_vector_table :
+    {
+        _host_vector_base = .;
+        KEEP(*(._host_vectors))
+    } > FLASH_BANK_1
+
+    ._host_handlers _host_entry_point :
+    {
+        KEEP(*(._host_handlers))
+    } > FLASH_BANK_1
+
+    ._host_text :
+    {
+        KEEP(*(.text))
+        KEEP(*(.text.*))
+    } > FLASH_BANK_1
+
+    /* Enclave Header */
+    ._enclave_header _host_app_address :
+    {
+        _enclave_start = .;
+        KEEP(*(.app.enclave_header))
+    } > FLASH_BANK_1
+
+    /* Enclave Code */
+    ._enclave_code :
+    {
+        _enclave_code_start = .;
+        KEEP(*(.app.enclave_code))
+        KEEP(*(.app.*))
+        . = _enclave_code_start + 0x400;
+    } > FLASH_BANK_1
+
+    .rodata :
+    {
+        *(.rodata*)
+    } > FLASH_BANK_1
+
+    .data :
+    {
+        _sdata = .;
+        *(.data*)
+        _edata = .;
+    } > SRAM_0 AT > FLASH_BANK_1
+
+    _sidata = LOADADDR(.data);
+
+    .bss :
+    {
+        _sbss = .;
+        *(.bss*)
+        *(COMMON)
+        _ebss = .;
+    } > SRAM_0
+}
+
+/* Guard: .bss (includes FreeRTOS 32KB heap) must not collide with MSP stack */
+ASSERT(_ebss < _host_sstack, "ERROR: BSS/heap overlaps MSP stack region!");
+
+/* NSC veneer addresses — same as bare_metal_arm */
+PROVIDE(umbra_tee_create = 0x0803c001);
+PROVIDE(umbra_debug_print = 0x0803c011);
+PROVIDE(umbra_enclave_enter = 0x0803c021);
+PROVIDE(umbra_enclave_exit = 0x0803c031);
+PROVIDE(umbra_enclave_status = 0x0803c041);

--- a/host/freertos_arm/linker/memory.ld
+++ b/host/freertos_arm/linker/memory.ld
@@ -1,0 +1,30 @@
+/*
+ * Memory regions for STM32L552 — FreeRTOS NS host demo.
+ * Self-contained copy (no dependency on bare_metal_arm/).
+ */
+
+MEMORY
+{
+    FLASH_BANK_0         (RXAL)  : ORIGIN = 0x08000000,                                      LENGTH = 256K,
+    FLASH_BANK_1         (RX)    : ORIGIN = ORIGIN(FLASH_BANK_0) + LENGTH(FLASH_BANK_0),     LENGTH = 256K,
+    SRAM_0               (RWX)   : ORIGIN = 0x20000000,                                      LENGTH = 128K,
+    SRAM_1               (RWX)   : ORIGIN = ORIGIN(SRAM_0) + LENGTH(SRAM_0),                 LENGTH = 64K
+}
+
+_host_entry_point = 0x08040100;
+
+/* Umbra Memory Block Aliases */
+MEMORY
+{
+    _SECURE_BOOT_TEXT_MEMORY_   (RXAL)   : ORIGIN = ORIGIN(FLASH_BANK_0),                                                       LENGTH = 68K,
+    _SECURE_KERNEL_TEXT_MEMORY_ (RXAL)   : ORIGIN = ORIGIN(_SECURE_BOOT_TEXT_MEMORY_) + LENGTH(_SECURE_BOOT_TEXT_MEMORY_),      LENGTH = 172K,
+    _NSC_TEXT_MEMORY_           (RXAL)   : ORIGIN = ORIGIN(_SECURE_KERNEL_TEXT_MEMORY_) + LENGTH(_SECURE_KERNEL_TEXT_MEMORY_),  LENGTH = 16K,
+    _SECURE_KERNEL_DATA_MEMORY_ (RWX)    : ORIGIN = 0x30030000,                                                                 LENGTH = 56K,
+    _NSC_DATA_MEMORY_           (RWX)    : ORIGIN = ORIGIN(_SECURE_KERNEL_DATA_MEMORY_) + LENGTH(_SECURE_KERNEL_DATA_MEMORY_),  LENGTH = 8K
+}
+
+ASSERT(ORIGIN(_SECURE_BOOT_TEXT_MEMORY_) + LENGTH(_SECURE_BOOT_TEXT_MEMORY_) == ORIGIN(_SECURE_KERNEL_TEXT_MEMORY_), "ERROR: SECURE_BOOT and SECURE_KERNEL regions are not contiguous!");
+ASSERT(ORIGIN(_SECURE_KERNEL_TEXT_MEMORY_) + LENGTH(_SECURE_KERNEL_TEXT_MEMORY_) == ORIGIN(_NSC_TEXT_MEMORY_),     "ERROR: SECURE_KERNEL and NSC regions are not contiguous!");
+ASSERT(ORIGIN(_NSC_TEXT_MEMORY_) + LENGTH(_NSC_TEXT_MEMORY_) <= ORIGIN(FLASH_BANK_1),                              "ERROR: Secure Flash Regions overlap with Host Flash (FLASH_BANK_1)!");
+ASSERT(ORIGIN(_SECURE_KERNEL_DATA_MEMORY_) + LENGTH(_SECURE_KERNEL_DATA_MEMORY_) == ORIGIN(_NSC_DATA_MEMORY_),     "ERROR: SECURE_KERNEL_DATA and NSC_DATA regions are not contiguous!");
+ASSERT(LENGTH(_SECURE_KERNEL_DATA_MEMORY_) + LENGTH(_NSC_DATA_MEMORY_) <= 64K,                                     "ERROR: Secure Data Regions exceed SRAM_1 size (64K)!");

--- a/host/freertos_arm/src/FreeRTOSConfig.h
+++ b/host/freertos_arm/src/FreeRTOSConfig.h
@@ -1,0 +1,64 @@
+#ifndef FREERTOS_CONFIG_H
+#define FREERTOS_CONFIG_H
+
+/* Clocks */
+#define configCPU_CLOCK_HZ          ( 4000000UL )   /* MSI default */
+#define configTICK_RATE_HZ          ( ( TickType_t ) 1000 )
+
+/* Scheduler */
+#define configUSE_PREEMPTION        1
+#define configMAX_PRIORITIES        ( 5 )
+#define configUSE_TIME_SLICING      1
+#define configIDLE_SHOULD_YIELD     1
+
+/* Memory */
+#define configMINIMAL_STACK_SIZE    ( ( unsigned short ) 128 )
+#define configTOTAL_HEAP_SIZE       ( ( size_t ) 32768 )
+#define configMAX_TASK_NAME_LEN     ( 16 )
+
+/* Features — keep minimal */
+#define configUSE_MUTEXES           0
+#define configUSE_RECURSIVE_MUTEXES 0
+#define configUSE_COUNTING_SEMAPHORES 0
+#define configUSE_TASK_NOTIFICATIONS 1
+#define configUSE_QUEUE_SETS        0
+#define configUSE_TIMERS            0
+#define configUSE_CO_ROUTINES       0
+
+/* Hooks */
+#define configUSE_IDLE_HOOK         0
+#define configUSE_TICK_HOOK         0
+#define configUSE_MALLOC_FAILED_HOOK 0
+#define configCHECK_FOR_STACK_OVERFLOW 2
+
+/* ARMv8-M / TrustZone — NTZ port */
+#define configENABLE_TRUSTZONE      0
+#define configENABLE_MPU            0
+#define configENABLE_FPU            0
+#define configRUN_FREERTOS_SECURE_ONLY 0
+
+/* Sizes */
+#define configUSE_16_BIT_TICKS      0
+#define configUSE_PORT_OPTIMISED_TASK_SELECTION 0
+
+/* API includes */
+#define INCLUDE_vTaskDelete         1
+#define INCLUDE_vTaskDelay          1
+#define INCLUDE_vTaskSuspend        1
+#define INCLUDE_xTaskGetSchedulerState 1
+
+/* ISR handler name mapping — these must match the names in startup.s vector table */
+#define vPortSVCHandler     SVC_Handler
+#define xPortPendSVHandler  PendSV_Handler
+#define xPortSysTickHandler SysTick_Handler
+
+/* Interrupt priority configuration for Cortex-M33.
+ * STM32L5 implements 3 priority bits (8 levels, shifted to top 5 bits).
+ * __NVIC_PRIO_BITS = 3 on this platform. */
+#define configPRIO_BITS             3
+#define configLIBRARY_LOWEST_INTERRUPT_PRIORITY       7
+#define configLIBRARY_MAX_SYSCALL_INTERRUPT_PRIORITY   5
+#define configKERNEL_INTERRUPT_PRIORITY        ( configLIBRARY_LOWEST_INTERRUPT_PRIORITY << ( 8 - configPRIO_BITS ) )
+#define configMAX_SYSCALL_INTERRUPT_PRIORITY   ( configLIBRARY_MAX_SYSCALL_INTERRUPT_PRIORITY << ( 8 - configPRIO_BITS ) )
+
+#endif /* FREERTOS_CONFIG_H */

--- a/host/freertos_arm/src/handlers.c
+++ b/host/freertos_arm/src/handlers.c
@@ -1,0 +1,27 @@
+/* NS fault handlers.  Defined in C (not assembly) so the linker
+ * preserves the Thumb interworking bit in vector table data relocations. */
+
+#include <stdint.h>
+
+extern void umbra_debug_print(const char *s);
+
+static char *u32_to_hex_h(uint32_t val, char *buf) {
+    const char hex[] = "0123456789ABCDEF";
+    buf[0] = '0'; buf[1] = 'x';
+    for (int i = 7; i >= 0; i--)
+        buf[2 + (7 - i)] = hex[(val >> (i * 4)) & 0xF];
+    buf[10] = '\0';
+    return buf;
+}
+
+void _host_Default_Handler(void)   { for (;;); }
+void _host_NMI_Handler(void)       { for (;;); }
+void _host_DebugMon_Handler(void)  { for (;;); }
+void _host_HardFault_Handler(void) { for (;;); }
+void _host_MemManage_Handler(void) { for (;;); }
+void _host_BusFault_Handler(void)  { for (;;); }
+
+/* Minimal — just spin. Use GDB to read:
+ *   x/1xw 0xE000ED28   (NS CFSR)
+ *   info reg            (stacked frame visible via PSP)  */
+void _host_UsageFault_Handler(void) { for (;;); }

--- a/host/freertos_arm/src/main.c
+++ b/host/freertos_arm/src/main.c
@@ -1,0 +1,157 @@
+#include "FreeRTOS.h"
+#include "task.h"
+#include "fibonacci.h"
+#include <stdint.h>
+
+/* --- Minimal hex printer (no printf) ------------------------------------ */
+static char *u32_to_hex(uint32_t val, char *buf) {
+    const char hex[] = "0123456789ABCDEF";
+    buf[0] = '0';
+    buf[1] = 'x';
+    for (int i = 7; i >= 0; i--) {
+        buf[2 + (7 - i)] = hex[(val >> (i * 4)) & 0xF];
+    }
+    buf[10] = '\0';
+    return buf;
+}
+
+/* --- Enclave header (same as bare_metal_arm) ----------------------------- */
+__attribute__((section(".app.enclave_header")))
+const uint8_t enclave_header[48] = {
+    0x55, 0x42, 0x4D, 0x52, // Magic: "UMBR"
+    0x01,                    // Trust_level (Trusted)
+    0x00,                    // reserved
+    0x01, 0x00,              // efbc_size (1)
+    0x00, 0x00,              // ess_blocks
+    0x00, 0x04, 0x00, 0x00,  // code_size (1024 bytes)
+    0x00, 0x00,              // reserved
+    // HMAC (32 bytes) — placeholder, overwritten by protect_enclave.py
+    0x37, 0x49, 0x09, 0xC7, 0x44, 0xB8, 0xD9, 0xA6, 0x9E, 0x8C, 0x2C, 0xF3,
+    0x41, 0x64, 0x0E, 0x57, 0x55, 0x32, 0xC0, 0xB7, 0xDF, 0x49, 0x83, 0x98,
+    0xCC, 0xC8, 0x30, 0x59, 0x03, 0xCC, 0xD9, 0x36};
+
+/* --- NSC veneer externs -------------------------------------------------- */
+extern unsigned int umbra_tee_create(unsigned int base_addr);
+extern void umbra_debug_print(const char *s);
+extern unsigned int umbra_enclave_enter(unsigned int enclave_id);
+extern unsigned int umbra_enclave_status(unsigned int enclave_id);
+
+extern uint8_t _enclave_start;
+
+/* --- Constants ----------------------------------------------------------- */
+#define NS_FLASH_END    0x08080000
+#define PAGE_SIZE       0x1000
+#define UMBRA_MAGIC     0x524D4255
+#define MAX_ENCLAVES    4
+
+#define STATUS_SUSPENDED  3
+#define STATUS_TERMINATED 4
+#define STATUS_FAULTED    5
+
+/* --- FreeRTOS task: scan, create, and run enclaves ----------------------- */
+static void vEnclaveTask(void *pvParameters) {
+    (void)pvParameters;
+
+    umbra_debug_print("[FREERTOS] Enclave task started\n");
+
+    /* Scan NS flash for enclave headers */
+    unsigned int enclave_ids[MAX_ENCLAVES];
+    unsigned int enclave_count = 0;
+
+    uint32_t scan_start =
+        ((uint32_t)(uintptr_t)&_enclave_start) & ~(PAGE_SIZE - 1);
+
+    for (uint32_t addr = scan_start;
+         addr < NS_FLASH_END && enclave_count < MAX_ENCLAVES;
+         addr += PAGE_SIZE) {
+        uint32_t magic = *(volatile uint32_t *)(uintptr_t)addr;
+        if (magic == UMBRA_MAGIC) {
+            unsigned int id = umbra_tee_create(addr);
+            if (id < 0xFFFFFFF0) {
+                enclave_ids[enclave_count++] = id;
+                umbra_debug_print("[FREERTOS] Enclave created\n");
+            } else {
+                umbra_debug_print("[FREERTOS] Enclave creation REJECTED\n");
+            }
+        }
+    }
+
+    if (enclave_count == 0) {
+        umbra_debug_print("[FREERTOS] No enclaves found\n");
+        vTaskDelete(NULL);
+        return;
+    }
+
+    /* Run enclaves until all terminate or fault */
+    unsigned int active = enclave_count;
+    while (active > 0) {
+        for (unsigned int i = 0; i < enclave_count; i++) {
+            if (enclave_ids[i] == 0)
+                continue;
+
+            unsigned int ret = umbra_enclave_enter(enclave_ids[i]);
+            unsigned int status = (ret >> 8) & 0xFF;
+            char hex_buf[11];
+
+            if (status == STATUS_SUSPENDED) {
+                umbra_debug_print("[FREERTOS] Enclave preempted (SysTick)\n");
+            } else if (status == STATUS_TERMINATED) {
+                unsigned int full_result = umbra_enclave_status(enclave_ids[i]);
+                umbra_debug_print("[FREERTOS] Enclave terminated! R0=");
+                umbra_debug_print(u32_to_hex(full_result, hex_buf));
+                umbra_debug_print("\n");
+                enclave_ids[i] = 0;
+                active--;
+            } else if (status == STATUS_FAULTED) {
+                umbra_debug_print("[FREERTOS] Enclave faulted — ret=");
+                umbra_debug_print(u32_to_hex(ret, hex_buf));
+                umbra_debug_print("\n");
+                enclave_ids[i] = 0;
+                active--;
+            }
+        }
+    }
+
+    umbra_debug_print("[FREERTOS] All enclaves done\n");
+    vTaskDelete(NULL);
+}
+
+/* --- FreeRTOS stack overflow hook ---------------------------------------- */
+void vApplicationStackOverflowHook(TaskHandle_t xTask, char *pcTaskName) {
+    (void)xTask;
+    (void)pcTaskName;
+    umbra_debug_print("[FREERTOS] STACK OVERFLOW!\n");
+    while (1) {}
+}
+
+/* --- Entry point --------------------------------------------------------- */
+
+#define SCB_VTOR  (*(volatile uint32_t *)0xE000ED08)
+#define SCB_SHCSR (*(volatile uint32_t *)0xE000ED24)
+
+/* SRAM vector table — defined in vectors.c */
+extern void *__vector_table[];
+
+int main(void) {
+    /* Set VTOR to SRAM vector table and enable NS fault handlers */
+    SCB_VTOR = (uint32_t)(uintptr_t)__vector_table;
+    SCB_SHCSR |= (1 << 16) | (1 << 17) | (1 << 18);
+
+    umbra_debug_print("[FREERTOS] Starting FreeRTOS demo\n");
+
+    xTaskCreate(
+        vEnclaveTask,       /* task function */
+        "Enclave",          /* name (debug only) */
+        512,                /* stack depth in words (2KB) */
+        NULL,               /* parameters */
+        1,                  /* priority (above idle) */
+        NULL                /* handle (not needed) */
+    );
+
+    vTaskStartScheduler();
+
+    /* Should never reach here */
+    umbra_debug_print("[FREERTOS] ERROR: scheduler returned\n");
+    while (1) {}
+    return 0;
+}

--- a/host/freertos_arm/src/mem.c
+++ b/host/freertos_arm/src/mem.c
@@ -1,0 +1,19 @@
+/* Minimal memset/memcpy for -nostdlib bare-metal builds.
+ * FreeRTOS tasks.c, queue.c, and heap_4.c require these. */
+
+#include <stddef.h>
+
+void *memset(void *s, int c, size_t n) {
+    unsigned char *p = s;
+    while (n--)
+        *p++ = (unsigned char)c;
+    return s;
+}
+
+void *memcpy(void *dest, const void *src, size_t n) {
+    unsigned char *d = dest;
+    const unsigned char *s = src;
+    while (n--)
+        *d++ = *s++;
+    return dest;
+}

--- a/host/freertos_arm/src/port_overrides.c
+++ b/host/freertos_arm/src/port_overrides.c
@@ -1,0 +1,34 @@
+/* Override FreeRTOS vStartFirstTask to avoid data-reading from the vector
+ * table base address.  On STM32L5 with TrustZone, the IDAU classifies
+ * 0x08040000 as Secure, so a NS data read triggers SecureFault even though
+ * the SAU marks the region NS (SAU only wins for instruction fetch).
+ *
+ * The original port code reads VT[0] via VTOR to reset MSP.  We load the
+ * initial MSP value from the linker symbol _host_estack instead. */
+
+#include <stdint.h>
+
+extern uint32_t _host_estack;
+
+/* Must match the SVC number in the FreeRTOS port (portmacrocommon.h) */
+#define portSVC_START_SCHEDULER    102
+
+void vStartFirstTask( void ) __attribute__(( naked ));
+
+void vStartFirstTask( void )
+{
+    __asm volatile
+    (
+        "   .syntax unified                                 \n"
+        "                                                   \n"
+        "   ldr r0, =_host_estack                           \n" /* Load initial MSP from linker symbol. */
+        "   msr msp, r0                                     \n" /* Set the MSP back to the start of the stack. */
+        "   cpsie i                                         \n" /* Globally enable interrupts. */
+        "   cpsie f                                         \n"
+        "   dsb                                             \n"
+        "   isb                                             \n"
+        "   svc %0                                          \n" /* System call to start the first task. */
+        "   nop                                             \n"
+        ::"i" ( portSVC_START_SCHEDULER ) : "memory"
+    );
+}

--- a/host/freertos_arm/src/startup.s
+++ b/host/freertos_arm/src/startup.s
@@ -1,0 +1,52 @@
+///////////////////////////////////////////////////////////////////////
+// FreeRTOS NS host startup for STM32L552 Cortex-M33
+// Only Reset_Handler lives here (needs .data/.bss init in assembly).
+// Vector table is in vectors.c, fault handlers in handlers.c.
+///////////////////////////////////////////////////////////////////////
+
+    .global _host_Reset_Handler
+    .extern _host_estack
+    .extern _sdata
+    .extern _edata
+    .extern _sidata
+    .extern _sbss
+    .extern _ebss
+
+    .thumb
+    .syntax unified
+    .section ._host_handlers, "ax"
+
+    .type _host_Reset_Handler, %function
+    .thumb_func
+    _host_Reset_Handler:
+        ldr sp, =_host_estack
+
+        // Copy .data from Flash to RAM
+        ldr r0, =_sdata
+        ldr r1, =_edata
+        ldr r2, =_sidata
+        movs r3, #0
+        b 2f
+    1:
+        ldr r4, [r2, r3]
+        str r4, [r0, r3]
+        adds r3, r3, #4
+    2:
+        add r4, r0, r3
+        cmp r4, r1
+        bcc 1b
+
+        // Zero .bss
+        ldr r0, =_sbss
+        ldr r1, =_ebss
+        movs r2, #0
+        b 4f
+    3:
+        str r2, [r0]
+        adds r0, r0, #4
+    4:
+        cmp r0, r1
+        bcc 3b
+
+        bl main
+        b .

--- a/host/freertos_arm/src/vectors.c
+++ b/host/freertos_arm/src/vectors.c
@@ -1,0 +1,55 @@
+/* NS vector table in SRAM.
+ *
+ * On STM32L5, the IDAU classifies 0x08040000 (NS flash) as Secure for
+ * DATA reads.  The SAU override only wins for instruction fetch.  Since
+ * the Cortex-M33 vector table fetch is architecturally a data read, the
+ * vector table MUST live in genuinely NS memory (SRAM_0, 0x20000000+).
+ *
+ * The array is non-const so it lands in .data (SRAM, initialized from
+ * flash by the startup .data copy loop).  VTOR is set to its SRAM
+ * address in main() before FreeRTOS starts.
+ *
+ * VTOR requires alignment to 2^ceil(log2(N*4)) where N = number of
+ * implemented exceptions.  STM32L5 has 125 entries → 512-byte alignment. */
+
+#include <stdint.h>
+
+/* Linker-defined symbols */
+extern uint32_t _host_estack;
+
+/* Handlers defined in startup.s */
+extern void _host_Reset_Handler(void);
+extern void _host_NMI_Handler(void);
+extern void _host_HardFault_Handler(void);
+extern void _host_MemManage_Handler(void);
+extern void _host_BusFault_Handler(void);
+extern void _host_UsageFault_Handler(void);
+extern void _host_DebugMon_Handler(void);
+
+/* FreeRTOS handlers (renamed via FreeRTOSConfig.h #defines) */
+extern void SVC_Handler(void);
+extern void PendSV_Handler(void);
+extern void SysTick_Handler(void);
+
+/* Use void* to preserve Thumb-interworking bit (LSB=1) for function
+ * addresses.  Casting to uint32_t strips the Thumb bit for assembly-
+ * defined symbols, causing ARM-mode faults on exception entry. */
+__attribute__((aligned(512), used))
+void *__vector_table[16] = {
+    (void *)&_host_estack,              /* 0x00: Initial MSP */
+    (void *)_host_Reset_Handler,        /* 0x04: Reset */
+    (void *)_host_NMI_Handler,          /* 0x08: NMI */
+    (void *)_host_HardFault_Handler,    /* 0x0C: HardFault */
+    (void *)_host_MemManage_Handler,    /* 0x10: MemManage */
+    (void *)_host_BusFault_Handler,     /* 0x14: BusFault */
+    (void *)_host_UsageFault_Handler,   /* 0x18: UsageFault */
+    (void *)0,                          /* 0x1C: Reserved */
+    (void *)0,                          /* 0x20: Reserved */
+    (void *)0,                          /* 0x24: Reserved */
+    (void *)0,                          /* 0x28: Reserved */
+    (void *)SVC_Handler,                /* 0x2C: SVCall */
+    (void *)_host_DebugMon_Handler,     /* 0x30: DebugMon */
+    (void *)0,                          /* 0x34: Reserved */
+    (void *)PendSV_Handler,             /* 0x38: PendSV */
+    (void *)SysTick_Handler,            /* 0x3C: SysTick */
+};

--- a/rebuild_all.sh
+++ b/rebuild_all.sh
@@ -2,4 +2,4 @@
 
 source ./settings.sh
 export UMBRA_ESS_MISS_RECOVERY=1
-make secureboot_clean && make secureboot_build && make umbra_clean && make umbra_build && cd host/bare_metal_arm && make clean && make && cd ../..
+make secureboot_clean && make secureboot_build && make umbra_clean && make umbra_build && cd ${HOST_DIR} && make clean && make && cd ${ROOT_DIR}

--- a/settings.sh
+++ b/settings.sh
@@ -367,8 +367,24 @@ echo -e ""
 
 echo -e "${BOLD}Configuring Host information${VANILLA}"
 
-# This should be a possible parameter in the future
-export HOST_ELF=${ROOT_DIR}/host/bare_metal_arm/bin/bare_metal_arm.elf
+# Host application selection
+# Options: bare_metal (default), freertos
+# Usage: export HOST_APP=freertos && source ./settings.sh
+export HOST_APP=${HOST_APP:-bare_metal}
 
+if [ "$HOST_APP" = "bare_metal" ]; then
+    export HOST_DIR=${ROOT_DIR}/host/bare_metal_arm
+    export HOST_NAME=bare_metal_arm
+elif [ "$HOST_APP" = "freertos" ]; then
+    export HOST_DIR=${ROOT_DIR}/host/freertos_arm
+    export HOST_NAME=freertos_arm
+else
+    echo -e "${FAILURE}[host_selection] Unknown HOST_APP: $HOST_APP${VANILLA}"
+    return 1
+fi
+
+export HOST_ELF=${HOST_DIR}/bin/${HOST_NAME}.elf
+
+echo -e "${SUCCESS}[host_selection] Selected host: $HOST_APP ($HOST_NAME)${VANILLA}"
 echo -e "${SUCCESS}[host_configuration] host elf is @ $HOST_ELF${VANILLA}"
 echo -e ""

--- a/src/hardware/platform/stm32l552/boot/src/main.rs
+++ b/src/hardware/platform/stm32l552/boot/src/main.rs
@@ -629,7 +629,13 @@ pub unsafe fn secure_boot() -> !{
     // Configure VTOR and MSP_NS       //
     /////////////////////////////////////
 
-    rcc::Rcc::set_vtor_ns(0x08040000);
+    // Point VTOR_NS to SRAM (0x20000000) where the NS host copies its
+    // vector table during .data initialization.  The IDAU on STM32L5
+    // classifies 0x08040000 as Secure for data reads, so the hardware
+    // vector fetch fails if VTOR points to flash.  SRAM is genuinely NS.
+    // This is safe for hosts without an SRAM vector table: they never
+    // trigger NS exceptions, so the stale SRAM content is never fetched.
+    rcc::Rcc::set_vtor_ns(0x20000000);
 
     /////////////////////////////////////
     // Jump to Non-Secure World        //


### PR DESCRIPTION
Add host/freertos_arm/ — a self-contained FreeRTOS host that proves Umbra's TrustZone isolation coexists with a standard RTOS scheduler. A single FreeRTOS task scans NS flash for enclaves, creates them via umbra_tee_create, and runs them via umbra_enclave_enter.

Key components:
- FreeRTOS-Kernel V11.1.0 submodule (ARM_CM33_NTZ port)
- SRAM vector table (STM32L5 IDAU blocks NS data reads from flash)
- vStartFirstTask override (avoids VT[0] data read, uses SVC #102)
- Fault handlers in C (assembly symbols lose Thumb bit in data relocs)
- HOST_APP env var to select host in settings.sh/rebuild_all.sh/debug.sh

Secure boot change: VTOR_NS set to 0x20000000 (SRAM) instead of 0x08040000 (flash). No regression on bare_metal_arm — it never triggers NS exceptions.

Documentation: mdBook "Host Examples" section with bare-metal and FreeRTOS pages, including TrustZone porting notes.

Tested on STM32L552 and STM32L562.