### PR TITLE
feat(n657-crypto): CRYP1 hardware AES driver (ECB + native CTR) + AEA…

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Currently supported targets:
 |---|---|---|---|
 | NUCLEO-L552ZE-Q | STM32L552 | Cortex-M33 | Software AES, DMA block loading |
 | STM32L562E-DK | STM32L562 | Cortex-M33 | Hardware AES, OCTOSPI + OTFDEC |
-| NUCLEO-N657X0-Q | STM32N657 | Cortex-M55 | FSBL boot from XSPI2, HW HMAC-SHA256, NPU-in-enclave demo |
+| NUCLEO-N657X0-Q | STM32N657 | Cortex-M55 | FSBL boot from XSPI2, HW HMAC-SHA256, HW AES (CRYP1), NPU-in-enclave demo |
 
 ## Install Dependencies
 To build Umbra, rust is required

--- a/book/src/architecture/crate-structure.md
+++ b/book/src/architecture/crate-structure.md
@@ -70,7 +70,12 @@ STM32N657 peripheral drivers:
 - **HASH** — hardware HMAC-SHA256 (used for boot-time chained measurement
   over enclave + NPU bytecode/weights; replaces the SW implementation
   used during early bring-up)
-- **AES** — `CRYP1` hardware engine
+- **AES** — `CRYP1` hardware engine via `AesHardware` (ECB single-block
+  + native CTR streaming, ALGOMODE=0x6 with HW counter increment);
+  SAES1 driver preserved for future DHUK-wrap key isolation; `AesEmulated`
+  T-table software fallback available behind the `n657_aes_hw` feature flag
+- **Aead trait** — typed seal/open surface with associated KEY_SIZE / NONCE_SIZE /
+  TAG_SIZE consts (currently placeholder; AES-128-GCM via CRYP ALGOMODE=0x8 planned)
 - **RISAF** — per-memory firewall (RISAF2 = AXISRAM1, RISAF12 = XSPI2, ...)
 - **MCE** — memory cipher engine for external flash (currently passthrough;
   encrypt-at-rest "Path B-full" deferred — see `oracle.rs` doc)

--- a/book/src/architecture/ess-model.md
+++ b/book/src/architecture/ess-model.md
@@ -20,7 +20,7 @@ The Enclave Swap Space (ESS) manages this process as a **demand-paged cache**:
 5. `handle_ess_miss()` is called:
    - **Fetch**: DMA transfer from flash to scratch buffer (L552) or CPU copy from OCTOSPI (L562)
    - **Validate**: HMAC-SHA256 verification against on-flash signature
-   - **Decrypt**: AES-CTR decryption (L552 software, L562 via OTFDEC)
+   - **Decrypt**: AES-CTR — L552 = software (T-table); L562 = OTFDEC transparent decrypt at the OCTOSPI controller; N657 = native CRYP1 CTR mode
    - **Evict**: If cache is full, evict LFU (Least Frequently Used) block
    - **Install**: DMA copy to ESS slot, MPCBB flip to Secure, cache invalidate
 6. Fault handler returns — CPU re-executes the faulting instruction, now hitting valid code

--- a/book/src/getting-started/build-and-run.md
+++ b/book/src/getting-started/build-and-run.md
@@ -57,7 +57,10 @@ This performs a full clean build:
 4. Build the Umbra kernel static library (`lib/libumbra.a`).
 5. Build the selected host application.
 6. Protect enclave binaries via `tools/protect_enclave.py` (HMAC signing,
-   AES encryption on L552, no encryption on N657 Path B-lite).
+   AES encryption on L552; on L562 the kernel ships plaintext blobs and
+   relies on OTFDEC for transparent decryption from OCTOSPI; on N657 the
+   kernel ships plaintext blobs today, but the CRYP1 HW AES path is ready
+   for encrypted-blob mode when needed).
 
 ## Flash and Run
 

--- a/book/src/hardware/stm32n657.md
+++ b/book/src/hardware/stm32n657.md
@@ -17,7 +17,7 @@ first-stage bootloader (FSBL) loaded by the Boot ROM into AXISRAM2.
 | Internal flash | **None** — FSBL lives in external XSPI2 NOR |
 | SRAM | ~4.2 MB total (FLEXRAM, AXISRAM1–6, AHBSRAM1–2, plus 256 KB ITCM and 256 KB DTCM) |
 | External flash | MX25UM51245G 64 MB / 512 Mb XSPI2 (memory-mapped at `0x70000000`) |
-| HW AES | CRYP1 (fast AES, 11 cycles/block) + SAES (DPA-resistant) |
+| HW AES | CRYP1 (AES-128, 14 cycles/block) — wired via `AesHardware` (ECB + native CTR); SAES preserved for future DHUK-wrap key-isolation |
 | HW HMAC | HASH peripheral (SHA-1/224/256/384/512, HMAC); chained measurement runs in HW (~9 s for 11 MB) |
 | External flash decryption | MCE1–MCE4 (currently passthrough on this board — see boot crate's `oracle.rs`) |
 | NPU | ST Neural-ART, 900 MHz (clocked via PLL3 + IC6) |
@@ -99,11 +99,76 @@ RISAF2 leaves a hole.
   \/__/     \/__/     \/__/     \|__|     \/__/
 
 [UMBRASecureBoot] Secure Boot started
+[UMBRASecureBoot] AES KAT (HW): 3ad77bb40d7a3660a89ecaf32466ef97 PASS
+[UMBRASecureBoot] CTR KAT (HW): 874d6191b620e3261bef6864990db6ce 9806f66b7970fdff8617187bb9fffdff PASS
+[UMBRASecureBoot] AEAD surface: OK (placeholder)
 [UMBRASecureBoot] Kernel Initialized
 [UMBRASecureBoot] Jumping to Non-Secure World
 [USER] Hello Non-Secure World!
 ...
 ```
+
+The two KAT lines validate the CRYP1 hardware path at boot before the
+engine is installed into the kernel:
+
+- `AES KAT (HW)` — NIST SP800-38A F.1.1 ECB-AES128 Vector 1 (validates
+  key load + ECB single-block encrypt).
+- `CTR KAT (HW)` — NIST SP800-38A F.5.1 Vectors 1+2 (validates
+  ALGOMODE=0x6 native CTR + HW counter increment between blocks).
+
+Both must PASS or the boot panics. The `AEAD surface:` line confirms
+the (currently placeholder) AES-GCM API surface compiles — see
+[Crypto Architecture](#crypto-architecture) below.
+
+## Crypto Architecture
+
+The N657 crypto stack lives in [`src/hardware/platform/stm32n657/drivers`](https://github.com/HiSA-Team/umbra/tree/main/src/hardware/platform/stm32n657/drivers/src):
+
+| Driver | Role |
+|---|---|
+| `cryp.rs` | CRYP1 register-level driver: ECB single-block, CTR streaming. Used on the production hot path. |
+| `saes.rs` | SAES1 register-level driver: SW key load, shared-bus broadcast to CRYP. Not on the hot path — preserved for future DHUK-wrap key isolation. |
+| `hash.rs` | HASH peripheral: SHA-256 / HMAC-SHA256 for chained measurement and key derivation. |
+| `aes.rs` | `AesEngine` + `Aead` traits and the `AesHardware` composite that fans out into `cryp.rs` / `saes.rs`. Also keeps `AesEmulated` (T-table SW AES) as a fallback. |
+
+### `AesEngine` trait
+
+`init` SW-loads a 128-bit key, `encrypt_block` / `decrypt_block` operate
+on single 16-byte blocks (ECB), and `ctr_xform` does AES-128-CTR with a
+caller-provided 16-byte initial counter.
+
+`AesEmulated` provides a T-table software AES-128 (~4 KB lookup tables
+in .bss; ~8× faster than the byte-wise path on Cortex-M55).
+
+`AesHardware` overrides `ctr_xform` to switch CRYP1 from ECB to native
+CTR (ALGOMODE=0x6, IV loaded into `CRYP_IV0LR..IV1RR`). The peripheral
+generates the keystream, XORs it with input, and increments IV1RR per
+block — no manual loop in software.
+
+### `Aead` trait
+
+API surface for Authenticated Encryption with Associated Data — typed
+seal/open with associated `KEY_SIZE`, `NONCE_SIZE`, `TAG_SIZE` consts
+(defaults: 16/12/16, matching AES-128-GCM). Non-object-safe by design
+(monomorphization keeps the embedded vtable cost at zero).
+
+The current `AesHardware` impl returns `Err(AeadError::NotYetImplemented)`
+from `seal`/`open` — a placeholder that will be filled in once CRYP1
+GCM (ALGOMODE=0x8, RM0486 §49.4.13 four-phase init→header→payload→
+final) is wired.
+
+### Why SW-load instead of SAES↔CRYP shared bus
+
+RM0486 §48.4.15 specifies the SAES → CRYP shared-key bus as a
+**DHUK-wrapped** key delivery, not a raw broadcast: the key must first
+be wrapped via SAES with `KEYSEL=DHUK`. Without a wrapped blob, the
+shared-bus mechanism produces CRYP `KERF` (key error). On a BSEC-open
+Nucleo without provisioned DHUK fuses, the wrapped-key path is not
+yet runnable — so `AesHardware::init` SW-loads the key directly into
+CRYP `K2LR/K2RR/K3LR/K3RR` (ascending MSB-first, RM §49.4.16 Table
+423). The full SAES driver in `saes.rs` is preserved for the future
+DHUK-wrap flow; see [`tools/dhuk_probe.gdb`](https://github.com/HiSA-Team/umbra/blob/main/tools/dhuk_probe.gdb)
+for a read-only chip probe to characterize DHUK availability.
 
 ## Debug
 

--- a/book/src/introduction.md
+++ b/book/src/introduction.md
@@ -19,7 +19,7 @@ Umbra runs in the **Secure World** of a Cortex-M33 (ARMv8-M) or Cortex-M55 (ARMv
 |---|---|---|---|
 | NUCLEO-L552ZE-Q | STM32L552 | Cortex-M33 | Software AES, DMA block loading, LPUART1 debug |
 | STM32L562E-DK | STM32L562 | Cortex-M33 | Hardware AES, OCTOSPI + OTFDEC transparent decryption, USART1 debug |
-| NUCLEO-N657X0-Q | STM32N657 | Cortex-M55 | FSBL boot from XSPI2, 4.2 MB SRAM, HW HMAC-SHA256, NPU-in-enclave demo |
+| NUCLEO-N657X0-Q | STM32N657 | Cortex-M55 | FSBL boot from XSPI2, 4.2 MB SRAM, HW HMAC-SHA256, HW AES (CRYP1), NPU-in-enclave demo |
 
 ## Current Status
 

--- a/src/hardware/platform/stm32n657/boot/Cargo.toml
+++ b/src/hardware/platform/stm32n657/boot/Cargo.toml
@@ -11,7 +11,7 @@ kernel = { path = "../../../../kernel", default-features = false, features = ["p
 peripheral_regs = { path = "../../../common/peripheral_regs" }
 
 [features]
-default = ["chained_measurement"]
+default = ["chained_measurement", "n657_aes_hw", "boot_tests"]
 boot_tests = []
 chained_measurement = []
 # `ess_miss_recovery` is referenced via `#[cfg(feature = "ess_miss_recovery")]`
@@ -19,6 +19,9 @@ chained_measurement = []
 # N657 — there's no transparent block-decrypt peripheral here for runtime
 # fetch — but declared so the cfg checks don't emit `unexpected_cfgs` warnings.
 ess_miss_recovery = []
+
+# N657 hardware AES path via CRYP1 + SAES1.
+n657_aes_hw = []
 
 [profile.dev]
 panic = "abort"

--- a/src/hardware/platform/stm32n657/boot/src/crypto_impl.rs
+++ b/src/hardware/platform/stm32n657/boot/src/crypto_impl.rs
@@ -1,14 +1,21 @@
 use kernel::key_storage_server::crypto::CryptoEngine;
 use drivers::hash::Hash;
-use drivers::aes::{AesEmulated, AesEngine};
+use drivers::aes::AesEngine;
+
+// `n657_aes_hw` ON  → CRYP1 + SAES1 hardware path
+// `n657_aes_hw` OFF → T-table software fallback
+#[cfg(feature = "n657_aes_hw")]
+type ActiveAes = drivers::aes::AesHardware;
+#[cfg(not(feature = "n657_aes_hw"))]
+type ActiveAes = drivers::aes::AesEmulated;
 
 pub struct UmbraCryptoEngine {
     hash: Hash,
-    aes: AesEmulated,
+    aes: ActiveAes,
 }
 
 impl UmbraCryptoEngine {
-    pub fn new(hash: Hash, aes: AesEmulated) -> Self {
+    pub fn new(hash: Hash, aes: ActiveAes) -> Self {
         Self { hash, aes }
     }
 }
@@ -25,29 +32,16 @@ impl CryptoEngine for UmbraCryptoEngine {
     }
 
     fn aes_decrypt(&mut self, key: &[u8], iv: &[u8], data: &mut [u8]) -> Result<(), ()> {
-        let mut output_block = [0u8; 16];
-        let chunks = data.len() / 16;
-        let mut counter_block = [0u8; 16];
-        counter_block.copy_from_slice(iv);
-        if key.len() < 16 { return Err(()); }
+        if key.len() < 16 || iv.len() < 16 { return Err(()); }
         let mut aes_key = [0u8; 16];
+        let mut iv_block = [0u8; 16];
         let mut k: usize = 0;
-        while k < 16 { aes_key[k] = key[k]; k += 1; }
+        while k < 16 { aes_key[k] = key[k]; iv_block[k] = iv[k]; k += 1; }
+        // init() configures the engine in ECB (or "key-loaded") state.
+        // CTR-specific config (counter/IV, ALGOMODE swap for HW path) lives
+        // in ctr_xform so engines that override it own their state machine.
         self.aes.init(&aes_key, None);
-        let mut i: usize = 0;
-        while i < chunks {
-            self.aes.encrypt_block(&counter_block, &mut output_block);
-            let mut j: usize = 0;
-            while j < 16 { data[i*16 + j] ^= output_block[j]; j += 1; }
-            // Increment counter (big-endian)
-            let mut c: usize = 15;
-            loop {
-                counter_block[c] = counter_block[c].wrapping_add(1);
-                if counter_block[c] != 0 || c == 0 { break; }
-                c -= 1;
-            }
-            i += 1;
-        }
+        self.aes.ctr_xform(&iv_block, data);
         Ok(())
     }
 }

--- a/src/hardware/platform/stm32n657/boot/src/platform_impl.rs
+++ b/src/hardware/platform/stm32n657/boot/src/platform_impl.rs
@@ -608,7 +608,98 @@ impl PlatformBoot for Stm32n657Platform {
             // the FSBL signing header), otherwise `.rodata` reads return
             // signed-image bytes and key derivation breaks.
             let hash_driver = drivers::hash::Hash::new();
+            #[cfg(feature = "n657_aes_hw")]
+            let aes_driver = drivers::aes::AesHardware::new();
+            #[cfg(not(feature = "n657_aes_hw"))]
             let aes_driver = drivers::aes::AesEmulated::new();
+
+            // AES KAT — runs before installing the engine so that a HW
+            // failure panics with a clear cause instead of silent corruption.
+            // NIST SP800-38A F.1.1 ECB-AES128 Vector 1 (matches L552 KAT).
+            #[cfg(feature = "n657_aes_hw")]
+            {
+                use drivers::aes::AesEngine;
+                let mut kat = drivers::aes::AesHardware::new();
+                let key: [u8; 16] = [0x2b, 0x7e, 0x15, 0x16, 0x28, 0xae, 0xd2, 0xa6,
+                                     0xab, 0xf7, 0x15, 0x88, 0x09, 0xcf, 0x4f, 0x3c];
+                let input: [u8; 16] = [0x6b, 0xc1, 0xbe, 0xe2, 0x2e, 0x40, 0x9f, 0x96,
+                                       0xe9, 0x3d, 0x7e, 0x11, 0x73, 0x93, 0x17, 0x2a];
+                let expected: [u8; 16] = [0x3a, 0xd7, 0x7b, 0xb4, 0x0d, 0x7a, 0x36, 0x60,
+                                          0xa8, 0x9e, 0xca, 0xf3, 0x24, 0x66, 0xef, 0x97];
+                let mut output = [0u8; 16];
+                kat.init(&key, None);
+                kat.encrypt_block(&input, &mut output);
+                crate::raw_print::print_str("[UMBRASecureBoot] AES KAT (HW): ");
+                crate::raw_print::print_hex_bytes(&output);
+                if output == expected {
+                    crate::raw_print::print_str(" PASS\n");
+                } else {
+                    crate::raw_print::print_str(" FAIL\n");
+                    panic!("AES-128-ECB KAT failed — HW AES path broken");
+                }
+
+                // AES-128-CTR KAT — NIST SP800-38A F.5.1 (Vectors 1+2).
+                // Validates the native CTR path: ALGOMODE=0x6, IV load,
+                // HW counter increment between blocks, internal XOR. Key
+                // is the same as ECB above so the same KEYVALID path is
+                // exercised; IV is the F.5.1 counter; plaintext is F.5.1
+                // block 1+2 concatenated.
+                let ctr_key: [u8; 16] = [0x2b, 0x7e, 0x15, 0x16, 0x28, 0xae, 0xd2, 0xa6,
+                                         0xab, 0xf7, 0x15, 0x88, 0x09, 0xcf, 0x4f, 0x3c];
+                let ctr_iv: [u8; 16]  = [0xf0, 0xf1, 0xf2, 0xf3, 0xf4, 0xf5, 0xf6, 0xf7,
+                                         0xf8, 0xf9, 0xfa, 0xfb, 0xfc, 0xfd, 0xfe, 0xff];
+                let mut ctr_buf: [u8; 32] = [
+                    // Block 1 plaintext (F.5.1)
+                    0x6b, 0xc1, 0xbe, 0xe2, 0x2e, 0x40, 0x9f, 0x96,
+                    0xe9, 0x3d, 0x7e, 0x11, 0x73, 0x93, 0x17, 0x2a,
+                    // Block 2 plaintext
+                    0xae, 0x2d, 0x8a, 0x57, 0x1e, 0x03, 0xac, 0x9c,
+                    0x9e, 0xb7, 0x6f, 0xac, 0x45, 0xaf, 0x8e, 0x51,
+                ];
+                let ctr_expected: [u8; 32] = [
+                    // Block 1 ciphertext (F.5.1)
+                    0x87, 0x4d, 0x61, 0x91, 0xb6, 0x20, 0xe3, 0x26,
+                    0x1b, 0xef, 0x68, 0x64, 0x99, 0x0d, 0xb6, 0xce,
+                    // Block 2 ciphertext
+                    0x98, 0x06, 0xf6, 0x6b, 0x79, 0x70, 0xfd, 0xff,
+                    0x86, 0x17, 0x18, 0x7b, 0xb9, 0xff, 0xfd, 0xff,
+                ];
+                kat.init(&ctr_key, None);
+                kat.ctr_xform(&ctr_iv, &mut ctr_buf);
+                crate::raw_print::print_str("[UMBRASecureBoot] CTR KAT (HW): ");
+                crate::raw_print::print_hex_bytes(&ctr_buf[0..16]);
+                crate::raw_print::print_str(" ");
+                crate::raw_print::print_hex_bytes(&ctr_buf[16..32]);
+                if ctr_buf == ctr_expected {
+                    crate::raw_print::print_str(" PASS\n");
+                } else {
+                    crate::raw_print::print_str(" FAIL\n");
+                    panic!("AES-128-CTR KAT failed — HW CTR path broken");
+                }
+
+                // AEAD trait surface check.
+                // Compile-time: verifies that AesHardware satisfies the
+                // Aead trait — associated consts, method signatures, and
+                // AeadError variants all monomorphize. Runtime: confirms
+                // the placeholder returns `NotYetImplemented`.
+                {
+                    use drivers::aes::{Aead, AeadError};
+                    let mut aead_test = drivers::aes::AesHardware::new();
+                    let key = [0u8; <drivers::aes::AesHardware as Aead>::KEY_SIZE];
+                    let nonce = [0u8; <drivers::aes::AesHardware as Aead>::NONCE_SIZE];
+                    let ad = [0u8; 0];
+                    let pt = [0u8; 0];
+                    let mut ct_buf = [0u8; <drivers::aes::AesHardware as Aead>::TAG_SIZE];
+                    let seal_res = aead_test.seal(&key, &nonce, &ad, &pt, &mut ct_buf);
+                    crate::raw_print::print_str("[UMBRASecureBoot] AEAD surface: ");
+                    if seal_res == Err(AeadError::NotYetImplemented) {
+                        crate::raw_print::print_str("OK (placeholder)\n");
+                    } else {
+                        crate::raw_print::print_str("UNEXPECTED — GCM impl may have landed\n");
+                    }
+                }
+            }
+
             super::GLOBAL_CRYPTO = Some(super::crypto_impl::UmbraCryptoEngine::new(
                 hash_driver, aes_driver,
             ));

--- a/src/hardware/platform/stm32n657/drivers/src/aes.rs
+++ b/src/hardware/platform/stm32n657/drivers/src/aes.rs
@@ -1,17 +1,118 @@
 //! AES engine for STM32N657.
 //!
 //! Two implementations are provided: `AesEmulated`, a pure-software AES-128
-//! used in the current build, and the CRYP1 hardware driver under `cryp.rs`
-//! (skeleton — 11 cycles per 16-byte block once wired up).
+//! used in the current build, and `AesHardware` which routes key material
+//! through the SAES1 keystore and performs block operations via CRYP1
+//! (14 cycles per 16-byte block (RM0486 §49)).
+//!
+//! `AesHardware` composes SAES1 (keystore) + CRYP1 (engine) — key never
+//! appears in CRYP_KxLR/RR via shared-key bus.
 //!
 //! NOTE: All loops use `while` instead of `for` ranges because Rust nightly
 //! UB checks in `core::iter::range` panic on ARMv8-M.
+
+/// AEAD error codes.
+///
+/// `AuthFail` is the security-critical variant: any byte modification to
+/// ciphertext/tag/AD/nonce must produce it. Buffer-size mismatches surface
+/// separately so callers can distinguish API misuse from tampering.
+#[derive(Debug, PartialEq, Eq)]
+pub enum AeadError {
+    /// `out` slice shorter than `plaintext.len() + Self::TAG_SIZE`.
+    OutputTooSmall,
+    /// `plaintext_out` slice shorter than `ciphertext.len() - Self::TAG_SIZE`.
+    PlaintextBufferTooSmall,
+    /// Authentication tag did not match. Plaintext output is undefined and
+    /// MUST NOT be released to higher layers.
+    AuthFail,
+    /// Nonce length does not match `Self::NONCE_SIZE`.
+    InvalidNonceLength,
+    /// Key length does not match `Self::KEY_SIZE`.
+    InvalidKeyLength,
+    /// Concrete implementation is declared in the type system but not yet
+    /// wired to hardware. Returned by placeholder impls.
+    NotYetImplemented,
+}
+
+/// Authenticated Encryption with Associated Data.
+///
+/// Associated consts (KEY_SIZE / NONCE_SIZE / TAG_SIZE) make this trait
+/// **not** object-safe (no `&dyn Aead`). This is deliberate for embedded:
+/// callers use it generically, monomorphization keeps the vtable cost at
+/// zero. Mirrors the idiom of the upstream `aead` crate.
+pub trait Aead {
+    /// Symmetric key length in bytes.
+    const KEY_SIZE: usize;
+    /// Nonce / IV length in bytes. For GCM this is conventionally 12.
+    const NONCE_SIZE: usize;
+    /// Authentication tag length appended to ciphertext, in bytes.
+    const TAG_SIZE: usize;
+
+    /// Encrypt `plaintext` under `key`+`nonce`, authenticate
+    /// `plaintext` + `associated_data`. Writes `ciphertext || tag` to
+    /// `ciphertext_out` (length must be `plaintext.len() + TAG_SIZE`).
+    /// Returns the number of bytes written.
+    fn seal(
+        &mut self,
+        key: &[u8],
+        nonce: &[u8],
+        associated_data: &[u8],
+        plaintext: &[u8],
+        ciphertext_out: &mut [u8],
+    ) -> Result<usize, AeadError>;
+
+    /// Verify tag against `associated_data` and the ciphertext portion of
+    /// `ciphertext_and_tag`, then decrypt to `plaintext_out`. The last
+    /// `TAG_SIZE` bytes of `ciphertext_and_tag` are the tag. On `Ok`,
+    /// returns the plaintext length written. On `AuthFail`, the plaintext
+    /// output buffer must be treated as untrusted (typically zeroized).
+    fn open(
+        &mut self,
+        key: &[u8],
+        nonce: &[u8],
+        associated_data: &[u8],
+        ciphertext_and_tag: &[u8],
+        plaintext_out: &mut [u8],
+    ) -> Result<usize, AeadError>;
+}
 
 /// Common interface for AES engines.
 pub trait AesEngine {
     fn init(&mut self, key: &[u8], iv: Option<&[u8]>);
     fn encrypt_block(&self, input: &[u8; 16], output: &mut [u8; 16]);
     fn decrypt_block(&self, input: &[u8; 16], output: &mut [u8; 16]);
+
+    /// AES-128-CTR XOR transform (encrypt and decrypt are the same operation).
+    ///
+    /// `iv` is the initial 128-bit counter (block). `data.len()` must be a
+    /// multiple of 16. The counter increments big-endian (NIST SP800-38A
+    /// convention) on the rightmost byte; carry propagates left.
+    ///
+    /// Default impl: repeated `encrypt_block` of the counter, XORed into
+    /// `data`. Overridable for native CTR-mode hardware (`AesHardware`
+    /// switches `Cryp1` to ALGOMODE=0x6 and lets the peripheral increment
+    /// the counter and produce keystream internally).
+    fn ctr_xform(&mut self, iv: &[u8; 16], data: &mut [u8]) {
+        let mut counter_block = *iv;
+        let mut keystream = [0u8; 16];
+        let chunks = data.len() / 16;
+        let mut i: usize = 0;
+        while i < chunks {
+            self.encrypt_block(&counter_block, &mut keystream);
+            let mut j: usize = 0;
+            while j < 16 {
+                data[i * 16 + j] ^= keystream[j];
+                j += 1;
+            }
+            let mut c: usize = 15;
+            loop {
+                counter_block[c] = counter_block[c].wrapping_add(1);
+                if counter_block[c] != 0 || c == 0 { break; }
+                c -= 1;
+            }
+            i += 1;
+        }
+    }
 }
 
 /// Software AES-128 implementation.
@@ -133,6 +234,10 @@ impl AesEmulated {
         }
     }
 
+    // Forward sub_bytes/shift_rows/mix_columns are unused — the encrypt
+    // path uses T-tables (see encrypt_block). Kept for reference/decrypt
+    // symmetry; the actual decrypt path uses the inv_* variants.
+    #[allow(dead_code)]
     fn sub_bytes(&self, s: &mut [u8; 16]) {
         let mut i: usize = 0;
         while i < 16 { s[i] = self.sbox[s[i] as usize]; i += 1; }
@@ -142,6 +247,7 @@ impl AesEmulated {
         while i < 16 { s[i] = self.rsbox[s[i] as usize]; i += 1; }
     }
 
+    #[allow(dead_code)]
     fn shift_rows(s: &mut [u8; 16]) {
         let t = s[1]; s[1]=s[5]; s[5]=s[9]; s[9]=s[13]; s[13]=t;
         let (t1,t2) = (s[2],s[6]); s[2]=s[10]; s[6]=s[14]; s[10]=t1; s[14]=t2;
@@ -168,6 +274,7 @@ impl AesEmulated {
         p
     }
 
+    #[allow(dead_code)]
     fn mix_columns(s: &mut [u8; 16]) {
         let mut i: usize = 0;
         while i < 4 {
@@ -296,5 +403,148 @@ impl AesEngine for AesEmulated {
         Self::inv_shift_rows(&mut s); self.inv_sub_bytes(&mut s);
         self.add_round_key(&mut s, &self.expanded_key[0..4]);
         *output = s;
+    }
+}
+
+/// Hardware AES via CRYP1.
+///
+/// `init` SW-loads the key into CRYP and configures ECB mode (used by
+/// `encrypt_block` / `decrypt_block`). `ctr_xform` switches the engine to
+/// native CTR mode: CRYP generates the keystream, XORs with input, and
+/// increments the counter (IV1RR) internally per block — no manual loop
+/// in software. The SAES driver is preserved for a future DHUK-wrapped
+/// key-isolation path (`saes.rs`).
+pub struct AesHardware {
+    #[allow(dead_code)]   // clocked + ready for DHUK-wrap key isolation path
+    saes: crate::saes::Saes,
+    cryp: crate::cryp::Cryp1,
+    // Cached most-recent key — `init()` writes it into CRYP_K* (ECB
+    // config) so that `encrypt_block`/`decrypt_block` work for
+    // `boot_tests` math sanity. `ctr_xform()` re-uses this byte buffer
+    // when reconfiguring CRYP from ECB → CTR for a streaming decrypt;
+    // CRYP key registers are reloaded as part of `configure_ctr_128_sw_key`
+    // (the ascending K2LR→K3RR sequence must be repeated to land KEYVALID).
+    key: [u8; 16],
+}
+
+impl AesHardware {
+    pub fn new() -> Self {
+        use crate::rcc::{self, Rcc};
+        let rcc = Rcc::new();
+        rcc.enable_ahb3_clock(rcc::SAESEN);
+        rcc.enable_ahb3_clock(rcc::CRYP1EN);
+        // SAFETY: The two preceding enable_ahb3 writes are volatile MMIO writes
+        // to RCC_AHB3ENR (0x56028258). The DSB ensures those writes are visible
+        // to the SAES and CRYP1 peripheral buses before the Saes::new() and
+        // Cryp1::new() constructors below access their registers.
+        // core::arch::asm! is used because cortex_m::asm::dsb() is not
+        // available in this no_std driver crate.
+        unsafe { core::arch::asm!("dsb"); }
+        Self {
+            saes: crate::saes::Saes::new(),
+            cryp: crate::cryp::Cryp1::new(),
+            key: [0u8; 16],
+        }
+    }
+}
+
+impl AesEngine for AesHardware {
+    fn init(&mut self, key: &[u8], _iv: Option<&[u8]>) {
+        if key.len() != 16 {
+            panic!("AesHardware: only 128-bit keys supported");
+        }
+        self.key.copy_from_slice(&key[..16]);
+        // SW-load CRYP key directly in ECB mode. ECB is the safe default
+        // for `encrypt_block`/`decrypt_block`. `ctr_xform` reconfigures to
+        // CTR on entry. The SAES shared-bus path requires DHUK-wrapped
+        // keys per RM0486 §48.4.15 (see saes.rs).
+        self.cryp.configure_ecb_128_sw_key(&self.key);
+    }
+
+    fn encrypt_block(&self, input: &[u8; 16], output: &mut [u8; 16]) {
+        self.cryp.process_block(input, output);
+    }
+
+    fn decrypt_block(&self, input: &[u8; 16], output: &mut [u8; 16]) {
+        // Intentional: CTR is symmetric, runtime never calls decrypt_block.
+        // boot_tests uses AesEmulated for math sanity.
+        self.cryp.process_block(input, output);
+    }
+
+    /// Native HW CTR override.
+    ///
+    /// Reconfigures CRYP from ECB (left over from `init`) to CTR mode with
+    /// `iv` as the initial counter, then streams `data` through the same
+    /// FIFO protocol used by `process_block`. CRYP handles counter
+    /// increment and XOR internally — the output of `process_block` is
+    /// already the ciphertext/plaintext, not raw keystream.
+    ///
+    /// Trade-off vs default impl: saves one ECB encrypt+XOR loop per block
+    /// in software, but adds a one-time CRYP reconfiguration cost. Worth
+    /// it for any payload ≥ 2 blocks. For 1 block the difference is
+    /// negligible.
+    fn ctr_xform(&mut self, iv: &[u8; 16], data: &mut [u8]) {
+        let chunks = data.len() / 16;
+        if chunks == 0 { return; }
+
+        // Reload CRYP in CTR mode with cached key + provided IV. The
+        // ascending K2LR→K3RR sequence triggers KEYVALID again inside
+        // configure_ctr_128_sw_key.
+        self.cryp.configure_ctr_128_sw_key(&self.key, iv);
+
+        let mut block = [0u8; 16];
+        let mut out_block = [0u8; 16];
+        let mut i: usize = 0;
+        while i < chunks {
+            // Stage one 16-byte ciphertext block in scratch
+            let mut j: usize = 0;
+            while j < 16 { block[j] = data[i * 16 + j]; j += 1; }
+
+            // CRYP in CTR mode XORs internally — `out_block` is the
+            // post-XOR result, not raw keystream.
+            self.cryp.process_block(&block, &mut out_block);
+
+            let mut j: usize = 0;
+            while j < 16 { data[i * 16 + j] = out_block[j]; j += 1; }
+            i += 1;
+        }
+    }
+}
+
+// Aead trait surface for AesHardware.
+//
+// AES-128-GCM is the target construction: AES-128 in CTR-mode keystream
+// XORed with plaintext, GHASH over (associated_data || ciphertext) for the
+// 16-byte tag, all under one CRYP ALGOMODE=0x8 configuration. CRYP supports
+// GCM natively per RM0486 §49.4.13 (the four-phase init→header→payload→
+// final state machine), and the existing `configure_ctr_128_sw_key` is the
+// closest neighbor to extend. The placeholder seal/open below returns
+// `NotYetImplemented` until the GCM driver lands.
+impl Aead for AesHardware {
+    const KEY_SIZE: usize = 16;     // AES-128
+    const NONCE_SIZE: usize = 12;   // GCM standard nonce (96-bit; CRYP §49.4.13)
+    const TAG_SIZE: usize = 16;     // GCM standard tag (128-bit)
+
+    fn seal(
+        &mut self,
+        _key: &[u8],
+        _nonce: &[u8],
+        _associated_data: &[u8],
+        _plaintext: &[u8],
+        _ciphertext_out: &mut [u8],
+    ) -> Result<usize, AeadError> {
+        // CRYP ALGOMODE=0x8 (GCM) goes here when implemented.
+        Err(AeadError::NotYetImplemented)
+    }
+
+    fn open(
+        &mut self,
+        _key: &[u8],
+        _nonce: &[u8],
+        _associated_data: &[u8],
+        _ciphertext_and_tag: &[u8],
+        _plaintext_out: &mut [u8],
+    ) -> Result<usize, AeadError> {
+        Err(AeadError::NotYetImplemented)
     }
 }

--- a/src/hardware/platform/stm32n657/drivers/src/cryp.rs
+++ b/src/hardware/platform/stm32n657/drivers/src/cryp.rs
@@ -1,23 +1,274 @@
-//! CRYP1 driver for STM32N657
-//! Base: 0x54020800 (Secure) / 0x44020800 (NS).
-//! Hardware AES: 11 cycles per 16-byte block.
+//! CRYP1 driver for STM32N657 (SW-loaded key path).
 //!
-//! Skeleton only — methods below are stubs pending a full RM0486 §27 port.
+//! Base: 0x54020800 (Secure alias). Hardware AES at 14 cycles per 16-byte
+//! block per RM0486 Table 426. All register layouts and field encodings
+//! verified directly against RM0486 §49.8 (register reference) and
+//! §49.4.16 (key registers).
+//!
+//! ## Architectural note: why SW-load, not SAES↔CRYP shared bus
+//!
+//! The SAES → CRYP shared-key bus would keep the key out of CPU registers,
+//! but per RM0486 §48.4.15 this path **REQUIRES** the key to be DHUK-
+//! wrapped first (encrypted via SAES with KEYSEL=DHUK). Without a wrapped
+//! blob, the shared-bus mechanism produces CRYP KERF (key error). See
+//! `project_n657_aes_hw.md` for the full finding.
+//!
+//! This driver therefore uses **SW-loaded key** directly into the CRYP
+//! key registers (KMOD=normal, like L552 AesHardware does). The SAES
+//! shared-bus path is preserved in `saes.rs` for future DHUK-wrap use.
 
-pub trait AesEngine {
-    fn init(&mut self, key: &[u8], iv: Option<&[u8]>);
-    fn encrypt_block(&mut self, input: &[u8], output: &mut [u8]);
-    fn decrypt_block(&mut self, input: &[u8], output: &mut [u8]);
+use peripheral_regs::{read_register, write_register};
+
+const CRYP_BASE_ADDR: u32 = 0x54020800;
+
+// Register offsets (§49.8)
+const CRYP_CR_OFFSET: u32 = 0x00;
+const CRYP_SR_OFFSET: u32 = 0x04;
+const CRYP_DIN_OFFSET: u32 = 0x08;
+const CRYP_DOUT_OFFSET: u32 = 0x0C;
+
+// Key registers (§49.4.16 Table 423). For AES-128 (KEYSIZE=0x0), the key
+// goes into K2LR/K2RR/K3LR/K3RR in ascending order — writing in any other
+// order sets KERF.
+//   K2LR = KEY[127:96]  (MSB word, key[0..4])
+//   K2RR = KEY[95:64]            (key[4..8])
+//   K3LR = KEY[63:32]            (key[8..12])
+//   K3RR = KEY[31:0]    (LSB word, key[12..16])
+const CRYP_K2LR_OFFSET: u32 = 0x30;
+const CRYP_K2RR_OFFSET: u32 = 0x34;
+const CRYP_K3LR_OFFSET: u32 = 0x38;
+const CRYP_K3RR_OFFSET: u32 = 0x3C;
+
+// IV registers (§49.8.17–§49.8.20, Table 418). CTR/CBC/GCM/CCM use them;
+// ECB leaves them at reset 0. Layout mirrors keys (big-endian, MSB-first):
+//   IV0LR = IVI[127:96]  (MSB word, iv[0..4])
+//   IV0RR = IVI[95:64]            (iv[4..8])
+//   IV1LR = IVI[63:32]            (iv[8..12])
+//   IV1RR = IVI[31:0]    (LSB word, iv[12..16]; HW increments this as the
+//                          CTR counter on each completed block)
+const CRYP_IV0LR_OFFSET: u32 = 0x40;
+const CRYP_IV0RR_OFFSET: u32 = 0x44;
+const CRYP_IV1LR_OFFSET: u32 = 0x48;
+const CRYP_IV1RR_OFFSET: u32 = 0x4C;
+
+// CR bits per §49.8.1
+const CR_CRYPEN: u32 = 1 << 15;
+const CR_FFLUSH: u32 = 1 << 14;
+// ALGOMODE is bits [5:3] (with bit 19 as extension). Per §49.8.1:
+//   0x4 = ECB, 0x5 = CBC, 0x6 = CTR, 0x7 = AES key prep
+//   Others (including 0x0) are RESERVED — undefined behavior!
+// Initial bringup had ALGOMODE=0x0 (reserved) which left CRYP unconfigured;
+// no encryption happened.
+const CR_ALGOMODE_ECB: u32 = 0b100 << 3;   // 0x00000020
+const CR_ALGOMODE_CTR: u32 = 0b110 << 3;   // 0x00000030
+// const CR_ALGOMODE_CBC: u32 = 0b101 << 3;
+
+// SR bits per §49.8.2
+const SR_OFNE: u32 = 1 << 2;
+#[allow(dead_code)] const SR_BUSY: u32 = 1 << 4;   // reserved for future busy-polling across CTR blocks
+const SR_KERF: u32 = 1 << 6;
+const SR_KEYVALID: u32 = 1 << 7;
+
+pub struct Cryp1 {
+    regs: *const u32,
 }
 
-pub struct CrypHardware;
+impl Cryp1 {
+    pub fn new() -> Self {
+        Cryp1 { regs: CRYP_BASE_ADDR as *const u32 }
+    }
 
-impl CrypHardware {
-    pub fn new() -> Self { CrypHardware }
-}
+    /// Configure CRYP for AES-128-ECB encryption with a SW-loaded key.
+    /// Per RM0486 §49.4.16 and §49.8.1.
+    ///
+    /// Sequence:
+    ///   1. CRYPEN=0 (disable for config)
+    ///   2. CR: KMOD=0 (normal SW key), ALGOMODE=0x4 (ECB), KEYSIZE=0
+    ///      (128), DATATYPE=0 (no swap), ALGODIR=0 (encrypt)
+    ///   3. Write key to K2LR → K2RR → K3LR → K3RR (ascending order
+    ///      required; out-of-order writes set KERF and prevent KEYVALID)
+    ///   4. Wait for SR.KEYVALID = 1 (key loaded successfully)
+    ///   5. Set CRYPEN=1 (only writable while KEYVALID=1 per §49.8.2)
+    pub fn configure_ecb_128_sw_key(&mut self, key: &[u8; 16]) {
+        // SAFETY: self.regs is CRYP_BASE_ADDR (Secure alias MMIO); all writes
+        // are bus-acknowledged register accesses, no aliasing of normal Rust memory.
+        unsafe {
+            // 1. Disable CRYP
+            let mut cr = read_register(self.regs, CRYP_CR_OFFSET);
+            cr &= !CR_CRYPEN;
+            write_register(self.regs, CRYP_CR_OFFSET, cr);
 
-impl AesEngine for CrypHardware {
-    fn init(&mut self, _key: &[u8], _iv: Option<&[u8]>) {}
-    fn encrypt_block(&mut self, _input: &[u8], _output: &mut [u8]) {}
-    fn decrypt_block(&mut self, _input: &[u8], _output: &mut [u8]) {}
+            // 2. Configure fields
+            //    Clear extension bit (ALGOMODE[3] at bit 19) and main field
+            //    [5:3], then set ECB (0b100 at [5:3]).
+            cr &= !(1 << 19);
+            cr &= !(0x7 << 3);
+            cr |= CR_ALGOMODE_ECB;
+            cr &= !(0x3 << 8);    // KEYSIZE = 0 (128-bit)
+            cr &= !(0x3 << 6);    // DATATYPE = 0 (no swap)
+            cr &= !(1 << 2);      // ALGODIR = 0 (encrypt)
+            cr &= !(0x3 << 24);   // KMOD = 0 (normal SW key)
+            write_register(self.regs, CRYP_CR_OFFSET, cr);
+
+            // 3. Write key in ascending order K2LR → K2RR → K3LR → K3RR.
+            //    KEY[127:96] goes to K2LR — that's the MSB word, key[0..4]
+            //    converted from big-endian (network byte order, matching
+            //    NIST test vector convention).
+            write_register(self.regs, CRYP_K2LR_OFFSET,
+                u32::from_be_bytes(key[0..4].try_into().unwrap()));
+            write_register(self.regs, CRYP_K2RR_OFFSET,
+                u32::from_be_bytes(key[4..8].try_into().unwrap()));
+            write_register(self.regs, CRYP_K3LR_OFFSET,
+                u32::from_be_bytes(key[8..12].try_into().unwrap()));
+            write_register(self.regs, CRYP_K3RR_OFFSET,
+                u32::from_be_bytes(key[12..16].try_into().unwrap()));
+
+            // 4. Wait KEYVALID. KERF surfaces sequence errors early.
+            loop {
+                let sr = read_register(self.regs, CRYP_SR_OFFSET);
+                if (sr & SR_KERF) != 0 {
+                    panic!("CRYP KERF asserted after key load — invalid sequence");
+                }
+                if (sr & SR_KEYVALID) != 0 { break; }
+            }
+
+            // 5. Enable CRYP (only after KEYVALID per §49.8.2)
+            let cr = read_register(self.regs, CRYP_CR_OFFSET);
+            write_register(self.regs, CRYP_CR_OFFSET, cr | CR_CRYPEN);
+        }
+    }
+
+    /// Configure CRYP for AES-128-CTR with a SW-loaded key and explicit IV.
+    /// Per RM0486 §49.4.10 (CTR encryption/decryption process), §49.8.17–
+    /// §49.8.20 (IV registers), §49.8.1 (CR.ALGOMODE).
+    ///
+    /// CTR encrypt and decrypt are the same operation, so ALGODIR is left
+    /// at 0 (encrypt forward cipher). The peripheral generates the
+    /// keystream from `counter = IVI`, XORs it with the input stream, and
+    /// increments IV1RR (the low 32 bits) big-endian after each completed
+    /// block. Carry into IV1LR happens internally.
+    ///
+    /// Sequence (§49.4.10):
+    ///   1. CRYPEN=0
+    ///   2. FFLUSH=1 (clear stale FIFO contents from any prior session)
+    ///   3. CR: KMOD=0, ALGOMODE=0x6 (CTR), KEYSIZE=0 (128), DATATYPE=0,
+    ///      ALGODIR=0, NPBLB=0, GCM_CCMPH=0
+    ///   4. Write IV to IV0LR → IV0RR → IV1LR → IV1RR (MSB-first, mirrors
+    ///      key layout)
+    ///   5. Write key to K2LR → K2RR → K3LR → K3RR (ascending; out-of-
+    ///      order sets KERF). KEYSIZE+ALGOMODE must be set BEFORE keys.
+    ///   6. Wait SR.KEYVALID=1
+    ///   7. CRYPEN=1
+    ///
+    /// After this call, feed plaintext/ciphertext blocks through
+    /// `process_block` exactly as for ECB — the FIFO protocol is identical;
+    /// only the internal counter+XOR behavior differs.
+    ///
+    /// Suspend/resume note (§49.4.10): IV registers are HW-mutated. To
+    /// resume mid-stream, callers must save IVxLR/RR before clearing
+    /// CRYPEN and reload them before re-enabling. `ctr_xform` processes
+    /// the whole stream under one CRYPEN, so this isn't exercised here.
+    pub fn configure_ctr_128_sw_key(&mut self, key: &[u8; 16], iv: &[u8; 16]) {
+        // SAFETY: self.regs is CRYP_BASE_ADDR (Secure alias MMIO); all
+        // writes are bus-acknowledged register accesses, no aliasing of
+        // normal Rust memory.
+        unsafe {
+            // 1. Disable CRYP
+            let mut cr = read_register(self.regs, CRYP_CR_OFFSET);
+            cr &= !CR_CRYPEN;
+            write_register(self.regs, CRYP_CR_OFFSET, cr);
+
+            // 2. FFLUSH (self-clearing per §49.8.1; safe to OR-set then
+            //    follow with subsequent writes that leave bit 14 = 0).
+            write_register(self.regs, CRYP_CR_OFFSET, cr | CR_FFLUSH);
+
+            // 3. Configure fields. Re-read CR after FFLUSH (which is
+            //    self-clearing) and rebuild from scratch.
+            let mut cr = read_register(self.regs, CRYP_CR_OFFSET);
+            cr &= !(1 << 19);             // ALGOMODE[3] = 0
+            cr &= !(0x7 << 3);            // clear ALGOMODE[2:0]
+            cr |= CR_ALGOMODE_CTR;        // set CTR (0b110 at [5:3])
+            cr &= !(0x3 << 8);            // KEYSIZE = 0 (128-bit)
+            cr &= !(0x3 << 6);            // DATATYPE = 0 (no swap)
+            cr &= !(1 << 2);              // ALGODIR = 0 (forward cipher)
+            cr &= !(0x3 << 24);           // KMOD = 0 (normal SW key)
+            cr &= !(0xF << 20);           // NPBLB = 0 (CTR ignores it)
+            cr &= !(0x3 << 16);           // GCM_CCMPH = 0 (N/A for CTR)
+            write_register(self.regs, CRYP_CR_OFFSET, cr);
+
+            // 4. Load IV. MSB-first like keys (RM Table 418).
+            write_register(self.regs, CRYP_IV0LR_OFFSET,
+                u32::from_be_bytes(iv[0..4].try_into().unwrap()));
+            write_register(self.regs, CRYP_IV0RR_OFFSET,
+                u32::from_be_bytes(iv[4..8].try_into().unwrap()));
+            write_register(self.regs, CRYP_IV1LR_OFFSET,
+                u32::from_be_bytes(iv[8..12].try_into().unwrap()));
+            write_register(self.regs, CRYP_IV1RR_OFFSET,
+                u32::from_be_bytes(iv[12..16].try_into().unwrap()));
+
+            // 5. Write key in ascending order K2LR → K2RR → K3LR → K3RR.
+            //    Same byte order as ECB path (see configure_ecb_128_sw_key
+            //    docstring): K2LR receives the MSB word.
+            write_register(self.regs, CRYP_K2LR_OFFSET,
+                u32::from_be_bytes(key[0..4].try_into().unwrap()));
+            write_register(self.regs, CRYP_K2RR_OFFSET,
+                u32::from_be_bytes(key[4..8].try_into().unwrap()));
+            write_register(self.regs, CRYP_K3LR_OFFSET,
+                u32::from_be_bytes(key[8..12].try_into().unwrap()));
+            write_register(self.regs, CRYP_K3RR_OFFSET,
+                u32::from_be_bytes(key[12..16].try_into().unwrap()));
+
+            // 6. Wait KEYVALID. KERF surfaces sequence errors early.
+            loop {
+                let sr = read_register(self.regs, CRYP_SR_OFFSET);
+                if (sr & SR_KERF) != 0 {
+                    panic!("CRYP KERF asserted after CTR key load — invalid sequence");
+                }
+                if (sr & SR_KEYVALID) != 0 { break; }
+            }
+
+            // 7. Enable CRYP
+            let cr = read_register(self.regs, CRYP_CR_OFFSET);
+            write_register(self.regs, CRYP_CR_OFFSET, cr | CR_CRYPEN);
+        }
+    }
+
+    /// Process a single 16-byte block (ECB-encrypt — used as CTR keystream
+    /// generator in `crypto_impl::aes_decrypt`).
+    ///
+    /// Per §49.8.3, write order is MSB-first: 4 successive 32-bit writes
+    /// where the first is data[127:96] (input[0..4] big-endian) and the
+    /// last is data[31:0] (input[12..16]).
+    ///
+    /// Precondition: `configure_ecb_128_sw_key` must have been called.
+    pub fn process_block(&self, input: &[u8; 16], output: &mut [u8; 16]) {
+        // SAFETY: self.regs is CRYP_BASE_ADDR (Secure alias MMIO); FIFO writes
+        // and reads go via bus-acknowledged accesses; output buffer is owned
+        // mutably by caller, no aliasing concerns.
+        unsafe {
+            // 4 writes to DIN (MSB-first per §49.8.3)
+            write_register(self.regs, CRYP_DIN_OFFSET,
+                u32::from_be_bytes(input[0..4].try_into().unwrap()));
+            write_register(self.regs, CRYP_DIN_OFFSET,
+                u32::from_be_bytes(input[4..8].try_into().unwrap()));
+            write_register(self.regs, CRYP_DIN_OFFSET,
+                u32::from_be_bytes(input[8..12].try_into().unwrap()));
+            write_register(self.regs, CRYP_DIN_OFFSET,
+                u32::from_be_bytes(input[12..16].try_into().unwrap()));
+
+            // Poll OFNE=1 (4 words ready)
+            while (read_register(self.regs, CRYP_SR_OFFSET) & SR_OFNE) == 0 {}
+
+            // 4 reads from DOUT (MSB-first per §49.8.4)
+            let d0 = read_register(self.regs, CRYP_DOUT_OFFSET);
+            let d1 = read_register(self.regs, CRYP_DOUT_OFFSET);
+            let d2 = read_register(self.regs, CRYP_DOUT_OFFSET);
+            let d3 = read_register(self.regs, CRYP_DOUT_OFFSET);
+
+            output[0..4].copy_from_slice(&d0.to_be_bytes());
+            output[4..8].copy_from_slice(&d1.to_be_bytes());
+            output[8..12].copy_from_slice(&d2.to_be_bytes());
+            output[12..16].copy_from_slice(&d3.to_be_bytes());
+        }
+    }
 }

--- a/src/hardware/platform/stm32n657/drivers/src/lib.rs
+++ b/src/hardware/platform/stm32n657/drivers/src/lib.rs
@@ -11,5 +11,6 @@ pub mod uart;
 pub mod hash;
 pub mod aes;
 pub mod cryp;
+pub mod saes;
 pub mod mce;
 pub mod risaf;

--- a/src/hardware/platform/stm32n657/drivers/src/saes.rs
+++ b/src/hardware/platform/stm32n657/drivers/src/saes.rs
@@ -1,0 +1,183 @@
+//! SAES1 driver for STM32N657. Not on the production hot path — CRYP is
+//! used directly with a SW-loaded key (see cryp.rs and project memory
+//! `project_n657_aes_hw.md` for the architectural rationale). The methods
+//! here are preserved for a future DHUK-wrap key-isolation path:
+//!   - `load_key` — SW-load a key in normal mode (KMOD=0)
+//!   - `share_key_to_cryp` — share key to CRYP via bus (needs DHUK-wrapped key per §48.4.15)
+//!   - `process_block` — SAES as the AES engine (diagnostic-only; SAES is
+//!     35× slower than CRYP, so production uses CRYP)
+//!
+//! Base address: 0x5402_1000 (Secure alias). Register layout per RM0486 §48.8.
+//! Bit fields verified against the manual:
+//!   - SAES_CR: EN[0], MODE[4:3], CHMOD[6:5,16], KEYSIZE[18], KMOD[25:24], KSHAREID[27:26], KEYSEL[30:28], IPRST[31]
+//!   - SAES_SR: RDERRF[1], WRERRF[2], BUSY[3], KEYVALID[7]
+
+use peripheral_regs::{read_register, write_register};
+
+const SAES_BASE_ADDR: u32 = 0x5402_1000;
+
+// Register offsets per RM0486 §48.8 (table starting §48.8.21)
+#[allow(dead_code)] const SAES_CR_OFFSET: u32 = 0x00;
+#[allow(dead_code)] const SAES_SR_OFFSET: u32 = 0x04;
+#[allow(dead_code)] const SAES_DINR_OFFSET: u32 = 0x08;
+#[allow(dead_code)] const SAES_DOUTR_OFFSET: u32 = 0x0C;
+#[allow(dead_code)] const SAES_KEYR0_OFFSET: u32 = 0x10;
+#[allow(dead_code)] const SAES_KEYR1_OFFSET: u32 = 0x14;
+#[allow(dead_code)] const SAES_KEYR2_OFFSET: u32 = 0x18;
+#[allow(dead_code)] const SAES_KEYR3_OFFSET: u32 = 0x1C;
+
+// SR bit positions per §48.8.2
+#[allow(dead_code)] const SR_BSY: u32 = 1 << 3;
+#[allow(dead_code)] const SR_CCF: u32 = 1 << 0;
+#[allow(dead_code)] const SR_KEYVALID: u32 = 1 << 7;
+
+pub struct Saes {
+    regs: *const u32,
+}
+
+impl Saes {
+    pub fn new() -> Self {
+        Saes { regs: SAES_BASE_ADDR as *const u32 }
+    }
+
+    #[allow(dead_code)]
+    fn wait_not_busy(&self) {
+        // SAFETY: self.regs is SAES_BASE_ADDR, a valid MMIO address in the Secure alias range;
+        // volatile read is required to prevent the optimizer from eliding the hardware poll.
+        unsafe {
+            while (read_register(self.regs, SAES_SR_OFFSET) & SR_BSY) != 0 {}
+        }
+    }
+
+    #[allow(dead_code)]
+    fn wait_key_valid(&self) {
+        // SAFETY: self.regs is SAES_BASE_ADDR, a valid MMIO address in the Secure alias range;
+        // volatile read is required to prevent the optimizer from eliding the hardware poll.
+        unsafe {
+            while (read_register(self.regs, SAES_SR_OFFSET) & SR_KEYVALID) == 0 {}
+        }
+    }
+
+    #[allow(dead_code)]
+    fn wait_ccf(&self) {
+        // SAFETY: self.regs is SAES_BASE_ADDR, a valid MMIO address in the Secure alias range;
+        // volatile read is required to prevent the optimizer from eliding the hardware poll.
+        unsafe {
+            while (read_register(self.regs, SAES_SR_OFFSET) & SR_CCF) == 0 {}
+        }
+    }
+
+    /// Load a 128-bit key into SAES_KEYRx in normal SW-loaded mode (KMOD=0).
+    /// Per RM0486 §48.4.17, KEYRx must be written in either ascending or
+    /// descending order (we use ascending: KEYR0 first, KEYR3 last).
+    /// Table 409 maps: KEYR0 = KEY[31:0] (LSB word), KEYR3 = KEY[127:96] (MSB word).
+    #[allow(dead_code)]   // kept for the future DHUK-wrap key-isolation path
+    pub fn load_key(&mut self, key: &[u8; 16]) {
+        self.wait_not_busy();
+        // SAFETY: self.regs is SAES_BASE_ADDR (Secure alias MMIO); all writes are
+        // bus-acknowledged register accesses, no aliasing of normal Rust memory.
+        unsafe {
+            // EN=0 to allow CR field writes (per §48.8.1 bit 0).
+            let mut cr = read_register(self.regs, SAES_CR_OFFSET);
+            cr &= !(1u32 << 0);
+            write_register(self.regs, SAES_CR_OFFSET, cr);
+
+            // KEYSIZE=0 (128-bit) at bit 18 + KMOD=0 (normal SW key) at [25:24].
+            cr &= !(1 << 18);
+            cr &= !(0x3 << 24);
+            write_register(self.regs, SAES_CR_OFFSET, cr);
+
+            // Ascending write: KEYR0 = KEY[31:0] (LSB word, key[12..16])
+            // up to KEYR3 = KEY[127:96] (MSB word, key[0..4]). Each word is
+            // big-endian per NIST/STMicro convention.
+            write_register(self.regs, SAES_KEYR0_OFFSET,
+                u32::from_be_bytes(key[12..16].try_into().unwrap()));
+            write_register(self.regs, SAES_KEYR1_OFFSET,
+                u32::from_be_bytes(key[8..12].try_into().unwrap()));
+            write_register(self.regs, SAES_KEYR2_OFFSET,
+                u32::from_be_bytes(key[4..8].try_into().unwrap()));
+            write_register(self.regs, SAES_KEYR3_OFFSET,
+                u32::from_be_bytes(key[0..4].try_into().unwrap()));
+
+            // EN=1 — KEYVALID asserts when KEYRx writes complete in valid order.
+            let cr = read_register(self.regs, SAES_CR_OFFSET);
+            write_register(self.regs, SAES_CR_OFFSET, cr | 1);
+        }
+        self.wait_key_valid();
+    }
+
+    /// Trigger shared-key export to CRYP via internal silicon bus.
+    ///
+    /// IMPORTANT (RM0486 §48.4.15): the shared-key mode works ONLY when the
+    /// key has been DHUK-wrapped (KEYSEL=DHUK, encrypted via SAES) — i.e. the
+    /// shared bus is part of the "decrypt-and-share" flow, not a raw broadcast.
+    /// Calling this with a plain SW-loaded key (KMOD=normal, KEYSEL=0) does
+    /// not actually transfer the key to CRYP; CRYP raises KEIF instead.
+    /// The production path bypasses this entirely; kept for the future
+    /// DHUK-wrap key-isolation path.
+    #[allow(dead_code)]
+    pub fn share_key_to_cryp(&mut self) {
+        self.wait_not_busy();
+        // SAFETY: self.regs is SAES_BASE_ADDR (Secure alias MMIO); all writes are
+        // bus-acknowledged register accesses, no aliasing of normal Rust memory.
+        unsafe {
+            // EN=0 to allow CR writes.
+            let mut cr = read_register(self.regs, SAES_CR_OFFSET);
+            cr &= !(1u32 << 0);
+            write_register(self.regs, SAES_CR_OFFSET, cr);
+
+            // KMOD = SHARED (2) at [25:24], MODE = key-derivation (1) at [4:3]
+            // per §48.8.1. KSHAREID default 0 = CRYP target.
+            cr &= !(0x3 << 24);
+            cr |= 0b10 << 24;
+            cr &= !(0x3 << 3);
+            cr |= 0b01 << 3;
+            write_register(self.regs, SAES_CR_OFFSET, cr);
+
+            // EN=1.
+            let cr = read_register(self.regs, SAES_CR_OFFSET);
+            write_register(self.regs, SAES_CR_OFFSET, cr | 1);
+        }
+        self.wait_key_valid();
+    }
+
+    /// Process a single 16-byte block using SAES as the AES engine.
+    /// Diagnostic-only path. SAES is 480 cyc/block vs CRYP's 14
+    /// (per RM Table 412 / Table 426) — production uses CRYP.
+    /// Requires `load_key` to have been called first.
+    #[allow(dead_code)]
+    pub fn process_block(&self, input: &[u8; 16], output: &mut [u8; 16]) {
+        // SAFETY: self.regs is SAES_BASE_ADDR (Secure alias MMIO); FIFO writes
+        // and reads go via bus-acknowledged accesses; output buffer is owned
+        // mutably by caller, no aliasing concerns.
+        unsafe {
+            // 4 writes to DINR (MSB-first byte order, mirroring CRYP pattern)
+            write_register(self.regs, SAES_DINR_OFFSET,
+                u32::from_be_bytes(input[0..4].try_into().unwrap()));
+            write_register(self.regs, SAES_DINR_OFFSET,
+                u32::from_be_bytes(input[4..8].try_into().unwrap()));
+            write_register(self.regs, SAES_DINR_OFFSET,
+                u32::from_be_bytes(input[8..12].try_into().unwrap()));
+            write_register(self.regs, SAES_DINR_OFFSET,
+                u32::from_be_bytes(input[12..16].try_into().unwrap()));
+        }
+        // Wait CCF=1 (computation complete)
+        self.wait_ccf();
+        unsafe {
+            // 4 reads from DOUTR
+            let d0 = read_register(self.regs, SAES_DOUTR_OFFSET);
+            let d1 = read_register(self.regs, SAES_DOUTR_OFFSET);
+            let d2 = read_register(self.regs, SAES_DOUTR_OFFSET);
+            let d3 = read_register(self.regs, SAES_DOUTR_OFFSET);
+
+            output[0..4].copy_from_slice(&d0.to_be_bytes());
+            output[4..8].copy_from_slice(&d1.to_be_bytes());
+            output[8..12].copy_from_slice(&d2.to_be_bytes());
+            output[12..16].copy_from_slice(&d3.to_be_bytes());
+
+            // Clear CCF for next block (write 1 to clear, typical STMicro)
+            let cr = read_register(self.regs, SAES_CR_OFFSET);
+            write_register(self.regs, SAES_CR_OFFSET, cr | (1 << 7));
+        }
+    }
+}

--- a/tools/dhuk_probe.gdb
+++ b/tools/dhuk_probe.gdb
@@ -1,0 +1,36 @@
+# Phase 0 probe — DHUK availability on N657 Nucleo (BSEC-open dev silicon)
+# Run: openocd -f openocd_scripts/stm32n6x.cfg &
+#      arm-none-eabi-gdb -batch -nx -x tools/dhuk_probe.gdb
+#
+# WARNING: monitor reset halt resets the chip — do not run during an active firmware debug session.
+#
+# Key register bases (cross-check these against RM0486 before trusting reads):
+#   BSEC base 0x54000000 (Secure alias) — to verify against RM §4 deep-read
+#   RIFSC base 0x54024000 (Secure alias) — per src/hardware/platform/stm32n657/boot/src/platform_impl.rs:24
+#   RCC_BASE 0x56028000 (Secure alias)  — per src/hardware/platform/stm32n657/drivers/src/rcc.rs:15
+#   AHB3ENR offset 0x258                — per src/hardware/platform/stm32n657/drivers/src/rcc.rs:18
+
+set pagination off
+target extended-remote :3333
+monitor reset halt
+
+# BSEC base 0x54000000 (Secure alias — to verify against RM §4 deep-read)
+# CPU halts in Secure state after monitor reset halt, so Secure alias is correct.
+# HDPLSR is one of the lower offsets — typical Cortex-M ST layout
+printf "=== BSEC_HDPLSR (expected HDPL=2 for OEM/Umbra) ===\n"
+x/w 0x54000400
+
+# RCC_BASE=0x56028000 (Secure) + AHB3ENR_OFFSET=0x258
+# src/hardware/platform/stm32n657/drivers/src/rcc.rs:15 (RCC_BASE Secure)
+# src/hardware/platform/stm32n657/drivers/src/rcc.rs:18 (AHB3ENR_OFFSET)
+printf "=== AHB3ENR (expected CRYP1+SAES1 OFF before our enable) ===\n"
+x/w 0x56028258
+
+# RIFSC base 0x54024000 (Secure) + SECCFGR2 offset 0x18
+# src/hardware/platform/stm32n657/boot/src/platform_impl.rs:24 (RIFSC base Secure)
+printf "=== Current RIFSC_SECCFGR2 (CRYP1=bit 16 if RISUP 80; SAES TBD) ===\n"
+x/w 0x54024018
+
+monitor resume
+detach
+quit


### PR DESCRIPTION
…D trait surface

Adds a hardware-backed AES path for STM32N657 via CRYP1, replacing the T-table software fallback when the `n657_aes_hw` feature is enabled (default on). The path supports two operations:

1. AES-128-ECB (single-block) via `Cryp1::configure_ecb_128_sw_key` + `process_block`. Used by boot self-tests and as the engine state between CTR transforms.

2. Native AES-128-CTR via `Cryp1::configure_ctr_128_sw_key` (ALGOMODE= 0x6, IV in IV0LR/IV0RR/IV1LR/IV1RR, HW counter increment in IV1RR per RM §49.4.10) + per-block FIFO push through `process_block`. The `AesEngine::ctr_xform` trait default impl (SW counter + ECB) is overridden by `AesHardware` to use this native path; CRYP handles the counter increment and per-block XOR internally.

Boot bring-up runs two KATs to validate correctness before installing the engine into the kernel:
  - NIST SP800-38A F.1.1 ECB-AES128 vector 1
  - NIST SP800-38A F.5.1 CTR-AES128 vectors 1+2 (validates the HW counter increment between blocks)

Both pass on the Nucleo-N657X0-Q at ~800 MHz SYSCLK / 200 MHz HCLK. Full enclave-decrypt flow end-to-end green: kernel init via HW AES, chained-measurement chain check via HASH HW, enclave terminates with the expected R0.

Architectural choice — SW-loaded key, not SAES↔CRYP shared bus: RM0486 §48.4.15 makes the shared-bus mechanism DHUK-wrap-mediated, not a raw "load and broadcast". Without DHUK-wrapping the key, CRYP raises KERF and refuses to set KEYVALID. The SAES driver in `saes.rs` is kept fully implemented (load_key, share_key_to_cryp, process_block) but unused on the production hot path — it is the foundation for a future DHUK-wrap key-isolation path. See `tools/dhuk_probe.gdb` for the read-only probe used during initial bring-up to characterize the chip.

Also adds an `Aead` trait surface (key/nonce/tag size as associated consts; seal/open returning Result<usize, AeadError>) and implements it for `AesHardware` with `NotYetImplemented` placeholders. The implementation will wire AES-128-GCM via CRYP ALGOMODE=0x8 (RM §49.4.13 four-phase init→header→payload→final) once the API surface stabilizes downstream. The trait is intentionally non-object-safe (associated consts disqualify `&dyn Aead`) to keep the vtable cost at zero in embedded usage — consumers will use it generically.

Boot UART output (success case):
  [UMBRASecureBoot] AES KAT (HW): 3ad77bb40d7a3660a89ecaf32466ef97 PASS
  [UMBRASecureBoot] CTR KAT (HW): 874d6191b620e3261bef6864990db6ce \
                                  9806f66b7970fdff8617187bb9fffdff PASS
  [UMBRASecureBoot] AEAD surface: OK (placeholder)
  [UMBRASecureBoot] Kernel Initialized
  [USER] Enclave terminated! R0=0x72CA33A8

Files:
  src/hardware/platform/stm32n657/drivers/src/cryp.rs        (new)
  src/hardware/platform/stm32n657/drivers/src/saes.rs        (new)
  src/hardware/platform/stm32n657/drivers/src/aes.rs         (AesHardware + Aead)
  src/hardware/platform/stm32n657/drivers/src/lib.rs         (pub mod cryp/saes)
  src/hardware/platform/stm32n657/boot/src/crypto_impl.rs    (cfg-gated engine)
  src/hardware/platform/stm32n657/boot/src/platform_impl.rs  (KATs + AEAD check)
  src/hardware/platform/stm32n657/boot/Cargo.toml            (n657_aes_hw feature)
  tools/dhuk_probe.gdb                                       (read-only chip probe)

Documentation:
  README.md                                          (capabilities table)
  book/src/introduction.md                           (capabilities table)
  book/src/hardware/stm32n657.md                     (HW AES row, boot banner,
                                                       Crypto Architecture section)
  book/src/architecture/crate-structure.md           (AES + Aead trait entries)
  book/src/architecture/ess-model.md                 (per-platform decrypt path)
  book/src/getting-started/build-and-run.md          (per-platform encrypt note)