### PR TITLE
chore(taclebench): promote tacle-bench to proper submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "host/stm32l552/freertos/lib/FreeRTOS-Kernel"]
 	path = host/stm32l552/freertos/lib/FreeRTOS-Kernel
 	url = https://github.com/FreeRTOS/FreeRTOS-Kernel.git
+[submodule "host/stm32l552/taclebench/lib/tacle-bench"]
+	path = host/stm32l552/taclebench/lib/tacle-bench
+	url = https://github.com/tacle/tacle-bench.git


### PR DESCRIPTION
Previously tacle-bench lived only as a "loose" submodule registered in local .git/config — it wasn't in .gitmodules, so a fresh clone (even with --recurse-submodules) wouldn't fetch it and the taclebench Makefile would fail to find lib/tacle-bench/bench/{kernel,sequential}.

Register the submodule properly:
  path = host/stm32l552/taclebench/lib/tacle-bench
  url  = https://github.com/tacle/tacle-bench.git
  pin  = a298a41 (V1.9, the commit already in use locally)